### PR TITLE
Make multi-statement DB mutations atomic + guard pre-migration writes

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -185,6 +185,21 @@ All styles in `app/globals.css`. Key classes:
 - `.config-ref` — reference info bar
 - `.prompt-versions`, `.prompt-version` — prompt history UI
 
+## Database Writes & Transactions
+
+Any API handler that issues **more than one** dependent write (delete-then-insert,
+create-then-insert, etc.) MUST run them atomically via the `withTransaction(fn)`
+helper in `lib/db.js` — never as separate `pool.query()` calls (mysql2 autocommits,
+so a mid-sequence failure leaves data half-written). `fn` receives a dedicated
+connection; the helper commits on success, rolls back on any throw, and always
+releases the connection. Examples: page section replacement, page create +
+sections, page-template section replacement.
+
+`page_template_sections` is migration-gated: it may not exist yet on older
+deployments. Before reading or writing it, guard with `tableExists(conn, "page_template_sections")`
+(or, on the read-only GET handlers, a try/catch) so saving a template / creating
+a page still works pre-migration.
+
 ## Coding Conventions
 
 - All admin pages are `"use client"` components

--- a/app/api/page-templates/[id]/route.js
+++ b/app/api/page-templates/[id]/route.js
@@ -1,4 +1,4 @@
-import pool from "@/lib/db";
+import pool, { withTransaction, tableExists } from "@/lib/db";
 import { NextResponse } from "next/server";
 
 export async function GET(req, { params }) {
@@ -17,15 +17,20 @@ export async function GET(req, { params }) {
 export async function PUT(req, { params }) {
   const { id } = await params;
   const { name, content, header_id, footer_id, sections } = await req.json();
-  await pool.query(
-    "UPDATE page_templates SET name=?, content=?, header_id=?, footer_id=? WHERE id=?",
-    [name, content, header_id || null, footer_id || null, id]
-  );
-  await pool.query("DELETE FROM page_template_sections WHERE page_template_id = ?", [id]);
-  if (sections?.length) {
-    const values = sections.map((s, i) => [id, s.section_type_id, s.sort_order ?? i]);
-    await pool.query("INSERT INTO page_template_sections (page_template_id, section_type_id, sort_order) VALUES ?", [values]);
-  }
+  await withTransaction(async (conn) => {
+    await conn.query(
+      "UPDATE page_templates SET name=?, content=?, header_id=?, footer_id=? WHERE id=?",
+      [name, content, header_id || null, footer_id || null, id]
+    );
+    // Skip section replacement if the migration hasn't been applied yet.
+    if (await tableExists(conn, "page_template_sections")) {
+      await conn.query("DELETE FROM page_template_sections WHERE page_template_id = ?", [id]);
+      if (sections?.length) {
+        const values = sections.map((s, i) => [id, s.section_type_id, s.sort_order ?? i]);
+        await conn.query("INSERT INTO page_template_sections (page_template_id, section_type_id, sort_order) VALUES ?", [values]);
+      }
+    }
+  });
   return NextResponse.json({ ok: true });
 }
 

--- a/app/api/page-templates/route.js
+++ b/app/api/page-templates/route.js
@@ -1,4 +1,4 @@
-import pool from "@/lib/db";
+import pool, { withTransaction, tableExists } from "@/lib/db";
 import { NextResponse } from "next/server";
 
 export async function GET() {
@@ -18,13 +18,17 @@ export async function GET() {
 
 export async function POST(req) {
   const { name, content, header_id, footer_id, sections } = await req.json();
-  const [r] = await pool.query(
-    "INSERT INTO page_templates (name, content, header_id, footer_id) VALUES (?, ?, ?, ?)",
-    [name, content, header_id || null, footer_id || null]
-  );
-  if (sections?.length) {
-    const values = sections.map((s, i) => [r.insertId, s.section_type_id, s.sort_order ?? i]);
-    await pool.query("INSERT INTO page_template_sections (page_template_id, section_type_id, sort_order) VALUES ?", [values]);
-  }
-  return NextResponse.json({ id: r.insertId }, { status: 201 });
+  const templateId = await withTransaction(async (conn) => {
+    const [r] = await conn.query(
+      "INSERT INTO page_templates (name, content, header_id, footer_id) VALUES (?, ?, ?, ?)",
+      [name, content, header_id || null, footer_id || null]
+    );
+    // Skip section creation if the migration hasn't been applied yet.
+    if (sections?.length && await tableExists(conn, "page_template_sections")) {
+      const values = sections.map((s, i) => [r.insertId, s.section_type_id, s.sort_order ?? i]);
+      await conn.query("INSERT INTO page_template_sections (page_template_id, section_type_id, sort_order) VALUES ?", [values]);
+    }
+    return r.insertId;
+  });
+  return NextResponse.json({ id: templateId }, { status: 201 });
 }

--- a/app/api/pages/[id]/route.js
+++ b/app/api/pages/[id]/route.js
@@ -1,4 +1,4 @@
-import pool from "@/lib/db";
+import pool, { withTransaction } from "@/lib/db";
 import { NextResponse } from "next/server";
 
 export async function GET(req, { params }) {
@@ -25,15 +25,17 @@ export async function GET(req, { params }) {
 export async function PUT(req, { params }) {
   const { id } = await params;
   const { title, slug, header_id, footer_id, page_template_id, status, sections, category_id } = await req.json();
-  await pool.query(
-    "UPDATE pages SET title=?, slug=?, header_id=?, footer_id=?, page_template_id=?, status=?, category_id=? WHERE id=?",
-    [title, slug, header_id || null, footer_id || null, page_template_id || 1, status, category_id || null, id]
-  );
-  await pool.query("DELETE FROM sections WHERE page_id = ?", [id]);
-  if (sections?.length) {
-    const values = sections.map((s, i) => [id, s.section_type_id, s.content, JSON.stringify(s.variables || {}), i]);
-    await pool.query("INSERT INTO sections (page_id, section_type_id, content, variables, sort_order) VALUES ?", [values]);
-  }
+  await withTransaction(async (conn) => {
+    await conn.query(
+      "UPDATE pages SET title=?, slug=?, header_id=?, footer_id=?, page_template_id=?, status=?, category_id=? WHERE id=?",
+      [title, slug, header_id || null, footer_id || null, page_template_id || 1, status, category_id || null, id]
+    );
+    await conn.query("DELETE FROM sections WHERE page_id = ?", [id]);
+    if (sections?.length) {
+      const values = sections.map((s, i) => [id, s.section_type_id, s.content, JSON.stringify(s.variables || {}), i]);
+      await conn.query("INSERT INTO sections (page_id, section_type_id, content, variables, sort_order) VALUES ?", [values]);
+    }
+  });
   return NextResponse.json({ ok: true });
 }
 

--- a/app/api/pages/route.js
+++ b/app/api/pages/route.js
@@ -1,4 +1,4 @@
-import pool from "@/lib/db";
+import pool, { withTransaction, tableExists } from "@/lib/db";
 import { NextResponse } from "next/server";
 
 export async function GET() {
@@ -16,48 +16,55 @@ export async function GET() {
 export async function POST(req) {
   const { title, slug, header_id, footer_id, page_template_id, status, sections, category_id } = await req.json();
 
-  // Blueprint expansion: inherit header/footer and sections from template
-  let effectiveHeaderId = header_id || null;
-  let effectiveFooterId = footer_id || null;
-  let blueprintSections = null;
+  const pageId = await withTransaction(async (conn) => {
+    // Blueprint expansion: inherit header/footer and sections from template
+    let effectiveHeaderId = header_id || null;
+    let effectiveFooterId = footer_id || null;
+    let blueprintSections = null;
 
-  if (page_template_id && !sections?.length) {
-    const [tpl] = await pool.query("SELECT header_id, footer_id FROM page_templates WHERE id = ?", [page_template_id]);
-    if (tpl.length) {
-      if (!effectiveHeaderId) effectiveHeaderId = tpl[0].header_id;
-      if (!effectiveFooterId) effectiveFooterId = tpl[0].footer_id;
-    }
-    const [bpSections] = await pool.query(
-      `SELECT pts.section_type_id, pts.sort_order, st.default_content, st.variables as type_variables
-       FROM page_template_sections pts
-       JOIN section_types st ON pts.section_type_id = st.id
-       WHERE pts.page_template_id = ? ORDER BY pts.sort_order`,
-      [page_template_id]
-    );
-    if (bpSections.length) blueprintSections = bpSections;
-  }
-
-  const [result] = await pool.query(
-    "INSERT INTO pages (title, slug, header_id, footer_id, page_template_id, status, category_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
-    [title, slug, effectiveHeaderId, effectiveFooterId, page_template_id || 1, status || "draft", category_id || null]
-  );
-  const pageId = result.insertId;
-
-  if (sections?.length) {
-    const values = sections.map((s, i) => [pageId, s.section_type_id, s.content, JSON.stringify(s.variables || {}), i]);
-    await pool.query("INSERT INTO sections (page_id, section_type_id, content, variables, sort_order) VALUES ?", [values]);
-  } else if (blueprintSections) {
-    const values = blueprintSections.map(s => {
-      // Auto-fill fixed variables
-      const typeVars = (() => { try { return JSON.parse(s.type_variables || "[]"); } catch { return []; } })();
-      const vars = {};
-      for (const v of typeVars) {
-        if (v.type === "fixed" && v.label) vars[v.key] = v.label;
+    if (page_template_id && !sections?.length) {
+      const [tpl] = await conn.query("SELECT header_id, footer_id FROM page_templates WHERE id = ?", [page_template_id]);
+      if (tpl.length) {
+        if (!effectiveHeaderId) effectiveHeaderId = tpl[0].header_id;
+        if (!effectiveFooterId) effectiveFooterId = tpl[0].footer_id;
       }
-      return [pageId, s.section_type_id, s.default_content, JSON.stringify(vars), s.sort_order];
-    });
-    await pool.query("INSERT INTO sections (page_id, section_type_id, content, variables, sort_order) VALUES ?", [values]);
-  }
+      // Skip blueprint sections if the migration hasn't been applied yet.
+      if (await tableExists(conn, "page_template_sections")) {
+        const [bpSections] = await conn.query(
+          `SELECT pts.section_type_id, pts.sort_order, st.default_content, st.variables as type_variables
+           FROM page_template_sections pts
+           JOIN section_types st ON pts.section_type_id = st.id
+           WHERE pts.page_template_id = ? ORDER BY pts.sort_order`,
+          [page_template_id]
+        );
+        if (bpSections.length) blueprintSections = bpSections;
+      }
+    }
+
+    const [result] = await conn.query(
+      "INSERT INTO pages (title, slug, header_id, footer_id, page_template_id, status, category_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      [title, slug, effectiveHeaderId, effectiveFooterId, page_template_id || 1, status || "draft", category_id || null]
+    );
+    const newPageId = result.insertId;
+
+    if (sections?.length) {
+      const values = sections.map((s, i) => [newPageId, s.section_type_id, s.content, JSON.stringify(s.variables || {}), i]);
+      await conn.query("INSERT INTO sections (page_id, section_type_id, content, variables, sort_order) VALUES ?", [values]);
+    } else if (blueprintSections) {
+      const values = blueprintSections.map(s => {
+        // Auto-fill fixed variables
+        const typeVars = (() => { try { return JSON.parse(s.type_variables || "[]"); } catch { return []; } })();
+        const vars = {};
+        for (const v of typeVars) {
+          if (v.type === "fixed" && v.label) vars[v.key] = v.label;
+        }
+        return [newPageId, s.section_type_id, s.default_content, JSON.stringify(vars), s.sort_order];
+      });
+      await conn.query("INSERT INTO sections (page_id, section_type_id, content, variables, sort_order) VALUES ?", [values]);
+    }
+
+    return newPageId;
+  });
 
   return NextResponse.json({ id: pageId }, { status: 201 });
 }

--- a/lib/db.js
+++ b/lib/db.js
@@ -48,6 +48,37 @@ export function getPool() {
   return pool;
 }
 
+// Run `fn` inside a single DB transaction. `fn` receives a dedicated
+// connection; on success the transaction commits, on any throw it rolls back.
+// The connection is always released back to the pool.
+export async function withTransaction(fn) {
+  const p = getPool();
+  if (!p) throw new Error("DB_NOT_CONFIGURED");
+  const conn = await p.getConnection();
+  try {
+    await conn.beginTransaction();
+    const result = await fn(conn);
+    await conn.commit();
+    return result;
+  } catch (err) {
+    try { await conn.rollback(); } catch { /* rollback best-effort */ }
+    throw err;
+  } finally {
+    conn.release();
+  }
+}
+
+// Whether `table` exists in the current database. Used to degrade gracefully
+// when a migration hasn't been applied yet (e.g. page_template_sections).
+// Works with either the pool or a transaction connection.
+export async function tableExists(executor, table) {
+  const [rows] = await executor.query(
+    "SELECT 1 FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ? LIMIT 1",
+    [table]
+  );
+  return rows.length > 0;
+}
+
 // Graceful shutdown — close pool on process exit and HMR reload
 function shutdownPool() { if (pool) { pool.end().catch(() => {}); pool = null; } }
 process.once("SIGTERM", shutdownPool);

--- a/lib/db.test.js
+++ b/lib/db.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import mysql from "mysql2/promise";
+
+// Mock mysql2/promise so getPool() never opens a real connection.
+vi.mock("mysql2/promise", () => ({
+  default: { createPool: vi.fn() },
+}));
+
+import { withTransaction } from "./db.js";
+
+function makeConn() {
+  return {
+    beginTransaction: vi.fn().mockResolvedValue(undefined),
+    commit: vi.fn().mockResolvedValue(undefined),
+    rollback: vi.fn().mockResolvedValue(undefined),
+    release: vi.fn(),
+    query: vi.fn().mockResolvedValue([[], []]),
+  };
+}
+
+// One pool is created lazily and cached inside db.js. Its getConnection always
+// hands out a fresh connection and records it in `lastConn`, so every test can
+// inspect the connection used by its withTransaction call.
+let lastConn;
+
+beforeEach(() => {
+  process.env.DB_HOST = "localhost";
+  process.env.DB_NAME = "test";
+  mysql.createPool.mockReturnValue({
+    getConnection: vi.fn(async () => {
+      lastConn = makeConn();
+      return lastConn;
+    }),
+  });
+});
+
+describe("withTransaction", () => {
+  it("commits on success, never rolls back, and releases the connection", async () => {
+    const result = await withTransaction(async (conn) => {
+      await conn.query("UPDATE x SET y=1");
+      return 42;
+    });
+
+    expect(result).toBe(42);
+    expect(lastConn.beginTransaction).toHaveBeenCalledTimes(1);
+    expect(lastConn.commit).toHaveBeenCalledTimes(1);
+    expect(lastConn.rollback).not.toHaveBeenCalled();
+    expect(lastConn.release).toHaveBeenCalledTimes(1);
+  });
+
+  it("rolls back on throw, never commits, releases, and rethrows", async () => {
+    await expect(
+      withTransaction(async () => {
+        throw new Error("boom");
+      })
+    ).rejects.toThrow("boom");
+
+    expect(lastConn.beginTransaction).toHaveBeenCalledTimes(1);
+    expect(lastConn.commit).not.toHaveBeenCalled();
+    expect(lastConn.rollback).toHaveBeenCalledTimes(1);
+    expect(lastConn.release).toHaveBeenCalledTimes(1);
+  });
+
+  it("rolls back the delete when a section insert fails (section-replacement path)", async () => {
+    // Mirrors the delete-then-insert sequence in the page/template routes:
+    // the DELETE succeeds but the bulk INSERT throws, so the whole unit must
+    // roll back rather than leave the page's sections wiped.
+    const insertError = new Error("ER_DATA_TOO_LONG");
+
+    await expect(
+      withTransaction(async (conn) => {
+        await conn.query("DELETE FROM sections WHERE page_id = ?", [1]);
+        conn.query.mockRejectedValueOnce(insertError);
+        await conn.query("INSERT INTO sections (...) VALUES ?", [[]]);
+      })
+    ).rejects.toThrow("ER_DATA_TOO_LONG");
+
+    // DELETE was issued, but the transaction is rolled back (not committed),
+    // so the delete is undone.
+    expect(lastConn.query).toHaveBeenCalledWith(
+      "DELETE FROM sections WHERE page_id = ?",
+      [1]
+    );
+    expect(lastConn.rollback).toHaveBeenCalledTimes(1);
+    expect(lastConn.commit).not.toHaveBeenCalled();
+    expect(lastConn.release).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
The codebase used zero transactions: every multi-statement write ran in
mysql2 autocommit, so a failure mid-sequence left data half-written. Most
damaging was page/template section replacement (DELETE then bulk INSERT) —
an insert failure wiped a page's sections with no restore.

- Add `withTransaction(fn)` + `tableExists(executor, table)` helpers to lib/db.js
- Wrap in a single transaction: page section replacement (pages/[id] PUT),
  page create + blueprint expansion + sections (pages POST), page-template
  section replacement (page-templates/[id] PUT) and create (page-templates POST)
- Guard the migration-gated `page_template_sections` table on every write/
  expansion path via tableExists, matching the graceful GET handlers, so
  saving a template / creating a page works pre-migration
- Add Vitest + unit tests for the helper (commit/rollback/release) and the
  section-replacement rollback-on-insert-failure path
- Document the transaction + migration-guard conventions in AGENT.md

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
