### PR TITLE
Harden /api/upload against malicious/malformed uploads

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -135,6 +135,14 @@ Special routes:
 - `POST /api/generate` — LLM generation (accepts provider, prompt, currentHtml, objectType, objectKey)
 - `POST/DELETE /api/upload` — S3 file upload/delete
 
+### Upload Validation
+
+`POST /api/upload` accepts image logo uploads only. Validation lives in `lib/uploadValidation.js` (`validateImageUpload`), kept separate from the route so it is unit-testable (`lib/uploadValidation.test.js`, Vitest). Rules:
+- Allowed extensions: `png`, `jpg`/`jpeg`, `webp`. Max size 5 MB (checked via `file.size` before buffering).
+- **SVG is intentionally disallowed** — it is XML that can carry inline `<script>`/external refs, so serving attacker-supplied SVG from our bucket is a stored-XSS vector. We reject rather than ship a sanitizer.
+- The stored S3 `ContentType` is derived from the validated extension, never from the client-supplied MIME type (spoofable). The S3 key uses only the validated extension, never the raw filename.
+- Filenames with no real extension are rejected (so a missing dot can't become the whole key).
+
 ### Secret Masking
 
 `system_config` API masks secret keys on GET (shows `••••••••` + last 4 chars). The masked keys are defined in `SECRET_KEYS` array in the route handler. On PUT, empty values for secret keys are skipped (preserves existing value).

--- a/app/api/upload/route.js
+++ b/app/api/upload/route.js
@@ -2,6 +2,7 @@ import { S3Client, PutObjectCommand, DeleteObjectCommand } from "@aws-sdk/client
 import pool from "@/lib/db";
 import { requireAuth } from "@/lib/auth";
 import { NextResponse } from "next/server";
+import { validateImageUpload } from "@/lib/uploadValidation";
 
 async function getS3Config() {
   const [rows] = await pool.query("SELECT config_key, config_value FROM system_config WHERE config_key IN ('aws_region','s3_bucket_name','aws_access_key','aws_secret_key')");
@@ -19,24 +20,40 @@ export async function POST(req) {
   const denied = await requireAuth(req);
   if (denied) return denied;
 
-  const formData = await req.formData();
-  const file = formData.get("file");
-  if (!file) return NextResponse.json({ error: "No file" }, { status: 400 });
+  let file;
+  try {
+    const formData = await req.formData();
+    file = formData.get("file");
+  } catch {
+    return NextResponse.json({ error: "Invalid upload" }, { status: 400 });
+  }
 
-  const cfg = await getS3Config();
-  const ext = file.name.split(".").pop();
-  const key = `site/logo-${Date.now()}.${ext}`;
-  const buffer = Buffer.from(await file.arrayBuffer());
+  // Validate type/extension/size up front, before buffering into memory.
+  const check = validateImageUpload(file);
+  if (!check.ok) {
+    return NextResponse.json({ error: check.error }, { status: check.status });
+  }
 
-  await getClient(cfg).send(new PutObjectCommand({
-    Bucket: cfg.s3_bucket_name,
-    Key: key,
-    Body: buffer,
-    ContentType: file.type,
-  }));
+  // Use only the server-validated extension/Content-Type for the stored object,
+  // never the attacker-controlled filename or client-supplied MIME type.
+  try {
+    const cfg = await getS3Config();
+    const key = `site/logo-${Date.now()}.${check.ext}`;
+    const buffer = Buffer.from(await file.arrayBuffer());
 
-  const url = `https://${cfg.s3_bucket_name}.s3.${cfg.aws_region}.amazonaws.com/${key}`;
-  return NextResponse.json({ url });
+    await getClient(cfg).send(new PutObjectCommand({
+      Bucket: cfg.s3_bucket_name,
+      Key: key,
+      Body: buffer,
+      ContentType: check.contentType,
+    }));
+
+    const url = `https://${cfg.s3_bucket_name}.s3.${cfg.aws_region}.amazonaws.com/${key}`;
+    return NextResponse.json({ url });
+  } catch {
+    // Don't leak internal/S3 error details to the client.
+    return NextResponse.json({ error: "Upload failed" }, { status: 500 });
+  }
 }
 
 export async function DELETE(req) {

--- a/lib/uploadValidation.js
+++ b/lib/uploadValidation.js
@@ -1,0 +1,70 @@
+// Validation for image uploads handled by app/api/upload/route.js.
+//
+// SVG is intentionally NOT allowed. SVG is an XML document that can carry
+// inline <script> and external references, so serving attacker-supplied SVG
+// from our own bucket is a stored-XSS vector. For a CMS logo upload the safe
+// default is to reject it rather than ship an SVG sanitizer here.
+export const MAX_UPLOAD_BYTES = 5 * 1024 * 1024; // 5 MB
+
+// Allowlist of extension -> canonical (server-derived) Content-Type.
+// The stored Content-Type is taken from this map, never from client input.
+const EXT_CONTENT_TYPE = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  webp: "image/webp",
+};
+
+// MIME types we accept on the inbound (spoofable) client header. This is a
+// coarse first gate only; the authoritative Content-Type comes from the
+// validated extension via EXT_CONTENT_TYPE.
+const ALLOWED_MIME = new Set(["image/png", "image/jpeg", "image/webp"]);
+
+/**
+ * Validate a multipart upload field.
+ *
+ * @param {unknown} file - the value pulled from formData.get("file")
+ * @returns {{ ok: true, ext: string, contentType: string }
+ *          | { ok: false, status: number, error: string }}
+ */
+export function validateImageUpload(file) {
+  // 1. Must be an actual File/Blob with the methods we rely on.
+  if (
+    !file ||
+    typeof file !== "object" ||
+    typeof file.arrayBuffer !== "function" ||
+    typeof file.size !== "number"
+  ) {
+    return { ok: false, status: 400, error: "No valid file uploaded" };
+  }
+
+  // 3. Cap size before any buffering into memory.
+  if (file.size <= 0) {
+    return { ok: false, status: 400, error: "Empty file" };
+  }
+  if (file.size > MAX_UPLOAD_BYTES) {
+    return { ok: false, status: 400, error: "File too large (max 5 MB)" };
+  }
+
+  // 5. Guard the no-dot filename case: require a real extension segment so a
+  // missing extension can't become the whole filename / a weird S3 key.
+  const name = typeof file.name === "string" ? file.name : "";
+  const dot = name.lastIndexOf(".");
+  if (dot <= 0 || dot === name.length - 1) {
+    return { ok: false, status: 400, error: "File must have an extension" };
+  }
+  const ext = name.slice(dot + 1).toLowerCase();
+
+  // 2. Enforce the extension allowlist.
+  const contentType = EXT_CONTENT_TYPE[ext];
+  if (!contentType) {
+    return { ok: false, status: 400, error: "Unsupported file type" };
+  }
+
+  // 2 (cont). Enforce the client MIME allowlist as a secondary gate.
+  if (typeof file.type === "string" && file.type && !ALLOWED_MIME.has(file.type)) {
+    return { ok: false, status: 400, error: "Unsupported file type" };
+  }
+
+  return { ok: true, ext, contentType };
+}

--- a/lib/uploadValidation.test.js
+++ b/lib/uploadValidation.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { validateImageUpload, MAX_UPLOAD_BYTES } from "./uploadValidation.js";
+
+// Minimal File/Blob stand-in: validateImageUpload only touches name/type/size
+// and the presence of an arrayBuffer method.
+function fakeFile({ name, type, size }) {
+  return { name, type, size, arrayBuffer: async () => new ArrayBuffer(0) };
+}
+
+describe("validateImageUpload", () => {
+  it("accepts a normal png", () => {
+    const r = validateImageUpload(fakeFile({ name: "logo.png", type: "image/png", size: 1234 }));
+    expect(r).toEqual({ ok: true, ext: "png", contentType: "image/png" });
+  });
+
+  it("accepts jpg/jpeg/webp and maps to canonical Content-Type", () => {
+    expect(validateImageUpload(fakeFile({ name: "a.JPG", type: "image/jpeg", size: 10 })).contentType).toBe("image/jpeg");
+    expect(validateImageUpload(fakeFile({ name: "a.jpeg", type: "image/jpeg", size: 10 })).contentType).toBe("image/jpeg");
+    expect(validateImageUpload(fakeFile({ name: "a.webp", type: "image/webp", size: 10 })).contentType).toBe("image/webp");
+  });
+
+  it("ignores a spoofed MIME type and trusts the extension for Content-Type", () => {
+    const r = validateImageUpload(fakeFile({ name: "logo.png", type: "", size: 10 }));
+    expect(r).toEqual({ ok: true, ext: "png", contentType: "image/png" });
+  });
+
+  it("rejects a missing/invalid file", () => {
+    expect(validateImageUpload(null).ok).toBe(false);
+    expect(validateImageUpload("not-a-file").ok).toBe(false);
+    expect(validateImageUpload({ name: "x.png", type: "image/png", size: 1 }).ok).toBe(false); // no arrayBuffer
+  });
+
+  it("rejects SVG by default", () => {
+    const r = validateImageUpload(fakeFile({ name: "x.svg", type: "image/svg+xml", size: 10 }));
+    expect(r.ok).toBe(false);
+    expect(r.status).toBe(400);
+  });
+
+  it("rejects disallowed extensions like .html", () => {
+    expect(validateImageUpload(fakeFile({ name: "evil.html", type: "text/html", size: 10 })).ok).toBe(false);
+  });
+
+  it("rejects a filename with no extension instead of using the whole name", () => {
+    expect(validateImageUpload(fakeFile({ name: "logo", type: "image/png", size: 10 })).ok).toBe(false);
+    expect(validateImageUpload(fakeFile({ name: "logo.", type: "image/png", size: 10 })).ok).toBe(false);
+    expect(validateImageUpload(fakeFile({ name: ".png", type: "image/png", size: 10 })).ok).toBe(false);
+  });
+
+  it("rejects an allowed extension whose client MIME is disallowed", () => {
+    const r = validateImageUpload(fakeFile({ name: "logo.png", type: "text/html", size: 10 }));
+    expect(r.ok).toBe(false);
+  });
+
+  it("rejects empty and oversized files", () => {
+    expect(validateImageUpload(fakeFile({ name: "a.png", type: "image/png", size: 0 })).ok).toBe(false);
+    expect(validateImageUpload(fakeFile({ name: "a.png", type: "image/png", size: MAX_UPLOAD_BYTES + 1 })).ok).toBe(false);
+    expect(validateImageUpload(fakeFile({ name: "a.png", type: "image/png", size: MAX_UPLOAD_BYTES })).ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Hardens `POST /api/upload` (logo upload), which previously pushed any multipart file straight to S3 with no validation: extension taken from the raw filename (the whole filename when there's no dot), attacker-controlled extension in the S3 key, `ContentType` from the spoofable client MIME, no size cap, and full in-memory buffering.

## Changes
- **`lib/uploadValidation.js`** (new) — `validateImageUpload`, kept separate from the route so it's unit-testable:
  - Rejects anything that isn't a real `File`/`Blob` (400).
  - Allowlist of image extensions **and** client MIME types: `png`, `jpg`/`jpeg`, `webp`.
  - Size capped at 5 MB via `file.size` **before** buffering; empty files rejected.
  - No-dot / trailing-dot / dotfile filenames rejected so a missing extension can't form a weird S3 key.
  - **SVG intentionally disallowed** — it's XML that can carry inline `<script>`/external refs (stored-XSS when served from our bucket); chose rejection over shipping a sanitizer.
- **`app/api/upload/route.js`** — validates up front; derives the stored S3 key extension **and** `ContentType` from the validated extension (never client input); wraps parsing/S3 in try/catch returning clean 400s and a generic 500 so internal details don't leak.
- **`lib/uploadValidation.test.js`** (new) — Vitest coverage of the validation logic.
- **`AGENT.md`** — records the SVG/validation decision as durable project knowledge.

## Backward compatibility
Legitimate `png`/`jpg`/`webp` logo uploads under 5 MB work unchanged.

## Out of scope
The endpoint's missing auth gate is handled separately; this PR only makes the validation correct and safe regardless of caller.

## Verification
- `npm run build` — exits 0.
- `npm test` — 16 tests pass (validation + existing template suite).