### PR TITLE
Make LLM HTML generation robust across providers (deep-sweep Finding 5)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -77,8 +77,12 @@ Each scope_key can have multiple versions. Only one is `is_active = 1` at a time
 
 1. Build system prompt: `system` + `{objectType}` + `{objectType}:{objectId}` (all active versions, concatenated)
 2. Build user message: current HTML template + user's ad-hoc prompt
-3. Call selected LLM provider (openai/claude/gemini)
-4. Return generated HTML
+3. Call selected LLM provider (openai/claude/gemini). Each provider function returns a normalized `{ rawText, truncated, model }` — `truncated` is derived from the provider's stop/finish reason (`finish_reason === "length"` / `stop_reason === "max_tokens"` / `finishReason === "MAX_TOKENS"`).
+4. Post-process via the shared helpers in `lib/llm.js` (kept provider-agnostic and unit-tested in `lib/llm.test.js`):
+   - `MAX_OUTPUT_TOKENS` — single output budget applied to all three providers (Claude was previously capped at 4096, which truncated full pages mid-tag).
+   - `cleanGeneratedHtml(rawText)` — empty/refusal guard (throws so empty HTML is **never** persisted to `generation_logs`) + `stripCodeFences` (removes a stray ```` ```html ```` wrapper the model may emit despite the "no fences" instruction).
+   - If `truncated`, the route returns HTTP 502 with a `truncated: true` warning instead of storing/returning the partial page.
+5. Return generated HTML
 
 ## URL Routing
 

--- a/app/api/generate/route.js
+++ b/app/api/generate/route.js
@@ -1,5 +1,6 @@
 import pool from "@/lib/db";
 import { requireAuth } from "@/lib/auth";
+import { MAX_OUTPUT_TOKENS, cleanGeneratedHtml } from "@/lib/llm";
 import { NextResponse } from "next/server";
 
 async function getKey(key) {
@@ -12,6 +13,12 @@ async function getActivePromptRow(scopeKey) {
   return rows[0] || null;
 }
 
+// Each provider returns a normalized shape: { rawText, truncated, model }.
+// rawText is the unprocessed model output (may be null/empty on a refusal or
+// content filter); truncated is true when the provider stopped because it hit
+// the output token budget. The POST handler applies the shared empty-guard /
+// fence-strip / truncation checks so all three behave identically.
+
 async function callOpenAI(apiKey, systemPrompt, userPrompt, imageData) {
   const OpenAI = (await import("openai")).default;
   const client = new OpenAI({ apiKey });
@@ -20,12 +27,20 @@ async function callOpenAI(apiKey, systemPrompt, userPrompt, imageData) {
   if (imageData) content.push({ type: "image_url", image_url: { url: `data:${imageData.mimeType};base64,${imageData.base64}` } });
   const res = await client.chat.completions.create({
     model,
+    max_tokens: MAX_OUTPUT_TOKENS,
     messages: [
       { role: "system", content: systemPrompt },
       { role: "user", content },
     ],
   });
-  return { html: res.choices[0].message.content, model };
+  const choice = res.choices?.[0];
+  // content is null on a content-filter stop; finish_reason "length" means the
+  // output was cut off at max_tokens.
+  return {
+    rawText: choice?.message?.content ?? "",
+    truncated: choice?.finish_reason === "length",
+    model,
+  };
 }
 
 async function callClaude(apiKey, systemPrompt, userPrompt, imageData) {
@@ -37,22 +52,40 @@ async function callClaude(apiKey, systemPrompt, userPrompt, imageData) {
   content.push({ type: "text", text: userPrompt });
   const res = await client.messages.create({
     model,
-    max_tokens: 4096,
+    max_tokens: MAX_OUTPUT_TOKENS,
     system: systemPrompt,
     messages: [{ role: "user", content }],
   });
-  return { html: res.content[0].text, model };
+  // The content array can lead with a non-text block (e.g. thinking); pick the
+  // first text block rather than assuming index 0. stop_reason "max_tokens"
+  // means the response was truncated at the budget.
+  const textBlock = res.content?.find((b) => b.type === "text");
+  return {
+    rawText: textBlock?.text ?? "",
+    truncated: res.stop_reason === "max_tokens",
+    model,
+  };
 }
 
 async function callGemini(apiKey, systemPrompt, userPrompt, imageData) {
   const { GoogleGenerativeAI } = await import("@google/generative-ai");
   const client = new GoogleGenerativeAI(apiKey);
   const model = "gemini-2.5-flash";
-  const genModel = client.getGenerativeModel({ model });
+  const genModel = client.getGenerativeModel({ model, generationConfig: { maxOutputTokens: MAX_OUTPUT_TOKENS } });
   const parts = [{ text: `${systemPrompt}\n\n${userPrompt}` }];
   if (imageData) parts.push({ inlineData: { mimeType: imageData.mimeType, data: imageData.base64 } });
   const res = await genModel.generateContent(parts);
-  return { html: res.response.text(), model };
+  // .text() throws if the candidate was blocked or returned no text; treat that
+  // as an empty completion rather than letting it escape. finishReason
+  // "MAX_TOKENS" means the output hit the budget.
+  let rawText = "";
+  try {
+    rawText = res.response?.text() ?? "";
+  } catch {
+    rawText = "";
+  }
+  const finishReason = res.response?.candidates?.[0]?.finishReason;
+  return { rawText, truncated: finishReason === "MAX_TOKENS", model };
 }
 
 export async function POST(req) {
@@ -79,6 +112,24 @@ export async function POST(req) {
     const handlers = { openai: callOpenAI, claude: callClaude, gemini: callGemini };
     const result = await (handlers[provider] || handlers.gemini)(apiKey, systemPrompt, userPrompt, imageData);
 
+    // Guard against empty/refused completions and strip any stray markdown
+    // fences. Throws if there is no usable HTML — handled below so we never
+    // persist empty HTML to generation_logs as if it were a complete page.
+    const html = cleanGeneratedHtml(result.rawText);
+
+    // If the provider truncated at the output budget, surface a clear warning
+    // instead of silently returning/storing a partial (mid-tag) page.
+    if (result.truncated) {
+      return NextResponse.json(
+        {
+          error:
+            "LLM response was truncated (hit the output token limit) — the HTML is incomplete. Try a shorter request or split it into sections.",
+          truncated: true,
+        },
+        { status: 502 }
+      );
+    }
+
     // Log generation
     await pool.query(
       `INSERT INTO generation_logs (provider, model, object_type, object_key,
@@ -92,11 +143,11 @@ export async function POST(req) {
         sysRow?.id || null, sysRow?.version || null,
         typeRow?.id || null, typeRow?.version || null,
         objRow?.id || null, objRow?.version || null,
-        prompt, currentHtml || null, result.html,
+        prompt, currentHtml || null, html,
       ]
     );
 
-    return NextResponse.json({ html: result.html });
+    return NextResponse.json({ html });
   } catch (e) {
     return NextResponse.json({ error: e.message }, { status: 500 });
   }

--- a/lib/llm.js
+++ b/lib/llm.js
@@ -1,0 +1,46 @@
+// Shared helpers for LLM HTML generation, used by every provider path in
+// app/api/generate/route.js (OpenAI, Claude, Gemini). Keeping the post-processing
+// here means the three providers behave identically and the logic is unit-testable
+// without pulling in the SDKs, the DB, or Next.js.
+
+// A single large output budget for full-page HTML, applied to all providers.
+// Claude was previously capped at 4096 (which truncated full landing pages
+// mid-tag) while OpenAI/Gemini were uncapped; standardizing avoids both the
+// truncation and the inconsistency. 8192 comfortably fits a full page and is
+// within the output limits of the models used here (gpt-4o-mini, Sonnet,
+// gemini-2.5-flash).
+export const MAX_OUTPUT_TOKENS = 8192;
+
+// Strip a single leading and/or trailing markdown code fence. The system prompt
+// tells the model to "return ONLY HTML, no fences", but models sometimes wrap
+// the output in ```html ... ``` anyway — and a stray fence renders as literal
+// text in a published page. Only the fence markers are removed; the HTML between
+// them is left untouched.
+export function stripCodeFences(text) {
+  if (typeof text !== "string") return text;
+  let out = text.trim();
+  // Opening fence: ``` optionally followed by a language tag (e.g. ```html),
+  // through the end of that line.
+  out = out.replace(/^```[^\n`]*\n?/, "");
+  // Closing fence: a trailing ``` on its own, optionally preceded by a newline.
+  out = out.replace(/\n?```\s*$/, "");
+  return out.trim();
+}
+
+// Guard against empty/refused completions and clean up stray fences. A
+// content-filtered or refused completion comes back as null/empty/whitespace;
+// returning that would persist empty HTML to generation_logs as if it were a
+// complete page. Throw instead so the caller can surface a clear error and skip
+// the insert. Returns fence-stripped HTML on success.
+export function cleanGeneratedHtml(rawText) {
+  if (typeof rawText !== "string" || rawText.trim() === "") {
+    throw new Error(
+      "LLM returned an empty response (the request may have been refused or content-filtered)"
+    );
+  }
+  const html = stripCodeFences(rawText);
+  if (html.trim() === "") {
+    throw new Error("LLM returned no usable HTML (only a code fence wrapper)");
+  }
+  return html;
+}

--- a/lib/llm.test.js
+++ b/lib/llm.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { stripCodeFences, cleanGeneratedHtml, MAX_OUTPUT_TOKENS } from "./llm.js";
+
+describe("stripCodeFences", () => {
+  it("strips a ```html fenced wrapper", () => {
+    expect(stripCodeFences("```html\n<div>hi</div>\n```")).toBe("<div>hi</div>");
+  });
+  it("strips a bare ``` fenced wrapper", () => {
+    expect(stripCodeFences("```\n<p>x</p>\n```")).toBe("<p>x</p>");
+  });
+  it("strips other language tags too", () => {
+    expect(stripCodeFences("```HTML\n<p>x</p>\n```")).toBe("<p>x</p>");
+  });
+  it("tolerates surrounding whitespace", () => {
+    expect(stripCodeFences("  \n```html\n<p>x</p>\n```  \n")).toBe("<p>x</p>");
+  });
+  it("strips a lone opening fence", () => {
+    expect(stripCodeFences("```html\n<p>x</p>")).toBe("<p>x</p>");
+  });
+  it("strips a lone closing fence", () => {
+    expect(stripCodeFences("<p>x</p>\n```")).toBe("<p>x</p>");
+  });
+  it("leaves unfenced HTML unchanged", () => {
+    const html = "<section>\n  <h1>Title</h1>\n</section>";
+    expect(stripCodeFences(html)).toBe(html);
+  });
+  it("does not touch backticks inside the HTML body", () => {
+    const html = "<code>const x = `t`;</code>";
+    expect(stripCodeFences(html)).toBe(html);
+  });
+  it("preserves a fenced code block in the middle of content", () => {
+    const html = "<p>before</p>\n```\nnot a wrapper\n```\n<p>after</p>";
+    expect(stripCodeFences(html)).toBe(html);
+  });
+  it("returns non-strings as-is", () => {
+    expect(stripCodeFences(null)).toBe(null);
+    expect(stripCodeFences(undefined)).toBe(undefined);
+  });
+});
+
+describe("cleanGeneratedHtml", () => {
+  it("returns fence-stripped HTML for a valid wrapped response", () => {
+    expect(cleanGeneratedHtml("```html\n<div>ok</div>\n```")).toBe("<div>ok</div>");
+  });
+  it("returns plain HTML unchanged", () => {
+    expect(cleanGeneratedHtml("<div>ok</div>")).toBe("<div>ok</div>");
+  });
+  it("throws on null (content filter / refusal)", () => {
+    expect(() => cleanGeneratedHtml(null)).toThrow(/empty response/);
+  });
+  it("throws on undefined", () => {
+    expect(() => cleanGeneratedHtml(undefined)).toThrow(/empty response/);
+  });
+  it("throws on an empty string", () => {
+    expect(() => cleanGeneratedHtml("")).toThrow(/empty response/);
+  });
+  it("throws on whitespace-only text", () => {
+    expect(() => cleanGeneratedHtml("   \n  ")).toThrow(/empty response/);
+  });
+  it("throws when only a code fence wrapper is present", () => {
+    expect(() => cleanGeneratedHtml("```html\n```")).toThrow(/no usable HTML/);
+  });
+});
+
+describe("MAX_OUTPUT_TOKENS", () => {
+  it("is a sane large budget for full-page HTML", () => {
+    expect(MAX_OUTPUT_TOKENS).toBeGreaterThanOrEqual(8192);
+  });
+});


### PR DESCRIPTION
Hardens `app/api/generate/route.js` so the OpenAI, Claude, and Gemini paths behave consistently and never persist broken HTML.

## Fixes
1. **Truncation** — All three providers now share `MAX_OUTPUT_TOKENS` (8192). Claude was capped at 4096 (truncated full landing pages mid-tag); OpenAI/Gemini were uncapped. Each provider's stop/finish reason is inspected (`finish_reason === "length"` / `stop_reason === "max_tokens"` / `finishReason === "MAX_TOKENS"`); on truncation the route returns HTTP 502 with a `truncated: true` warning instead of returning/storing a partial page.
2. **Markdown fences** — Shared `stripCodeFences` removes a stray ```` ```html ... ``` ```` wrapper a model may emit despite the "return ONLY HTML, no fences" instruction.
3. **Empty/null guard** — `cleanGeneratedHtml` throws on null/empty/whitespace (content filter or refusal) so empty HTML is never written to `generation_logs` as a complete page. Claude now picks the first text block rather than assuming index 0; Gemini's `.text()` (which throws on a blocked candidate) is guarded.

Shared logic lives in `lib/llm.js` (provider-agnostic, no SDK/DB/Next deps) and is unit-tested in `lib/llm.test.js`.

## Validation
- `npm run build` — exit 0
- `npm test` — 66 passing (7 files), including the new fence-strip / empty-guard tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)