### PR TITLE
Fix secret wipe-on-empty and substituteVars prototype-key leak

### DIFF
--- a/app/api/system-config/route.js
+++ b/app/api/system-config/route.js
@@ -54,6 +54,10 @@ export async function PUT(req) {
   const dbFields = {};
   for (const [key, value] of Object.entries(data)) {
     if (value === undefined) continue;
+    // Documented contract: empty/blank values for secret keys are skipped so a
+    // "Change" → Save with the box left empty preserves the stored secret
+    // (API key, AWS secret, DB password) instead of wiping it.
+    if (SECRET_KEYS.includes(key) && (value === null || String(value).trim() === "")) continue;
     if (key in DB_KEYS) {
       dbFields[key] = value;
     } else {

--- a/app/api/system-config/route.test.js
+++ b/app/api/system-config/route.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// The PUT handler persists each posted key to system_config. The contract
+// (AGENT.md "Secret Masking") is that an empty/blank value for a secret key is
+// skipped so a "Change" → Save with the box left empty preserves the stored
+// secret instead of wiping it. These tests drive PUT with a stubbed pool/auth.
+
+const { query } = vi.hoisted(() => ({
+  query: vi.fn().mockResolvedValue([[], []]),
+}));
+
+vi.mock("@/lib/db", () => ({
+  default: { query },
+  saveDbConfig: vi.fn(),
+  loadConfig: vi.fn(() => ({})),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  requireAuth: vi.fn().mockResolvedValue(null), // null = allowed
+}));
+
+vi.mock("next/server", () => ({
+  NextResponse: { json: (body) => ({ body }) },
+}));
+
+import { PUT } from "./route.js";
+
+function makeReq(data) {
+  return { json: async () => data };
+}
+
+// Keys persisted to system_config (config_key) via the INSERT ... ON DUPLICATE.
+function persistedKeys() {
+  return query.mock.calls.map((c) => c[1][0]);
+}
+
+beforeEach(() => {
+  query.mockClear();
+});
+
+describe("PUT /api/system-config — secret wipe protection", () => {
+  it("skips persisting an empty secret value (preserves existing secret)", async () => {
+    await PUT(makeReq({ openai_api_key: "" }));
+    expect(persistedKeys()).not.toContain("openai_api_key");
+  });
+
+  it("skips a whitespace-only secret value", async () => {
+    await PUT(makeReq({ aws_secret_key: "   " }));
+    expect(persistedKeys()).not.toContain("aws_secret_key");
+  });
+
+  it("still persists a non-empty secret value", async () => {
+    await PUT(makeReq({ claude_api_key: "sk-live-123" }));
+    const call = query.mock.calls.find((c) => c[1][0] === "claude_api_key");
+    expect(call).toBeTruthy();
+    expect(call[1][1]).toBe("sk-live-123");
+  });
+
+  it("does not change non-secret behavior: empty non-secret values are still persisted", async () => {
+    await PUT(makeReq({ site_title: "" }));
+    const call = query.mock.calls.find((c) => c[1][0] === "site_title");
+    expect(call).toBeTruthy();
+    expect(call[1][1]).toBe("");
+  });
+});

--- a/lib/template.js
+++ b/lib/template.js
@@ -4,8 +4,13 @@
  */
 export function substituteVars(template, config, { stripUnresolved = false } = {}) {
   if (!template) return template;
+  // Only resolve own keys: the `\w+` token matches prototype names like
+  // `__proto__`/`constructor`/`prototype`, and a bare `config[key]` would pull
+  // those off the prototype chain (e.g. leaking the Object constructor), so
+  // guard the lookup with Object.hasOwn before reading.
   return template.replace(/\{\{(\w+)\}\}/g, (_, key) =>
-    config[key] ?? (stripUnresolved ? "" : `{{${key}}}`)
+    (config && Object.hasOwn(config, key) ? config[key] : undefined) ??
+    (stripUnresolved ? "" : `{{${key}}}`)
   );
 }
 

--- a/lib/template.test.js
+++ b/lib/template.test.js
@@ -39,4 +39,23 @@ describe("substituteVars", () => {
       "Hi "
     );
   });
+
+  it("does not resolve prototype keys off the prototype chain", () => {
+    // `\w+` matches these tokens; a bare config[key] would leak Object internals
+    // (e.g. the constructor function) instead of treating them as unresolved.
+    expect(substituteVars("a {{constructor}} b", {})).toBe(
+      "a {{constructor}} b"
+    );
+    expect(substituteVars("a {{__proto__}} b", {})).toBe("a {{__proto__}} b");
+    expect(substituteVars("a {{prototype}} b", {})).toBe("a {{prototype}} b");
+    expect(
+      substituteVars("a {{constructor}} b", {}, { stripUnresolved: true })
+    ).toBe("a  b");
+  });
+
+  it("still resolves an own key that happens to share a prototype name", () => {
+    expect(substituteVars("v={{constructor}}", { constructor: "X" })).toBe(
+      "v=X"
+    );
+  });
 });


### PR DESCRIPTION
Fix 1 (system-config secret wipe): PUT only skipped value === undefined,
so sending "" for a secret key (Change → Save with the box left empty)
wiped the stored secret. Skip persisting secret-type keys (reusing the
SECRET_KEYS masking classification) when the incoming value is empty/blank,
matching the documented contract in AGENT.md. Non-secret behavior unchanged.

Fix 2 (substituteVars prototype leak): the {{\w+}} token matches prototype
names (__proto__, constructor, prototype) and a bare config[key] resolved
them off the prototype chain (e.g. leaking the Object constructor). Guard the
lookup with Object.hasOwn so only own keys resolve.

Adds Vitest coverage for both.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
