### PR TITLE
Fix DB-integrity issues: atomic prompt versioning, transactional category sync, migration runner

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -38,6 +38,8 @@ Glow CMS is a Next.js 16 App Router application with a MySQL backend. There is n
 pages.header_id → headers.id
 pages.footer_id → footers.id
 pages.page_template_id → page_templates.id
+pages.category_id → categories.id (SET NULL on delete)
+categories.parent_id → categories.id (self-ref, CASCADE delete)
 sections.page_id → pages.id (CASCADE delete)
 sections.section_type_id → section_types.id
 ```
@@ -72,6 +74,14 @@ Page templates additionally carry a `{{content}}` placeholder where assembled se
 ### Versioning
 
 Each scope_key can have multiple versions. Only one is `is_active = 1` at a time. Saving a new prompt creates a new version and deactivates the old one. Users can reactivate any previous version.
+
+The `prompts` table has `UNIQUE(scope_key, version)` (migration `004`), and the
+`POST`/`PUT /api/prompts` handlers run their `MAX(version)+1 → deactivate → insert`
+(and `deactivate → activate`) sequences inside `withTransaction` with `FOR UPDATE` on
+the max-version lookup. Together these stop concurrent saves from minting duplicate
+versions or leaving multiple/zero `is_active` rows — important because the active
+prompt drives every LLM call. The pure version-selection logic lives in `lib/prompts.js`
+(`nextPromptVersion`), unit-tested in `lib/prompts.test.js`.
 
 ### Generation Flow (`/api/generate`)
 
@@ -164,6 +174,14 @@ Special routes:
 - `GET /api/prompts/all` — list all scope_keys with summary
 - `POST /api/generate` — LLM generation (accepts provider, prompt, currentHtml, objectType, objectKey)
 - `POST/DELETE /api/upload` — S3 file upload/delete
+- `POST /api/categories/sync` — pull categories (L1) + treatments (L2) from the
+  external DB and upsert into local `categories`. The whole sync runs in one
+  `withTransaction` (a mid-loop FK failure rolls back rather than half-syncing).
+  L2 rows are keyed locally via `categoryLocalId(parent_id, id)` in `lib/categories.js`
+  (`parent_id * 100000 + id`), which throws on sibling-range collisions or signed-INT
+  overflow instead of writing a corrupt key; unit-tested in `lib/categories.test.js`.
+  **Reconciliation policy:** categories deleted externally are left in place (never
+  auto-deleted) so they can't orphan local pages.
 
 ### Upload Validation
 
@@ -275,6 +293,30 @@ All styles in `app/globals.css`. Key classes:
 - `.var-tag` — clickable variable pill (e.g. `{{site_title}}`)
 - `.config-ref` — reference info bar
 - `.prompt-versions`, `.prompt-version` — prompt history UI
+
+## Database Migrations
+
+`db/schema.sql` is the **from-scratch snapshot** applied to a brand-new database.
+`db/migrations/*.sql` are the **incremental, ordered** changes applied to existing
+databases. These two must never drift: **every change to `schema.sql` must also ship
+as a numbered migration**, and vice-versa.
+
+- **Runner**: `npm run migrate` (`db/migrate.mjs`) applies `db/migrations/*.sql` in
+  filename order and records each in a `schema_migrations` table so each file runs
+  exactly once. `npm run migrate -- --status` lists applied/pending without applying.
+  It reads DB config via `loadConfig()` (same env vars / `.db-config.json` as the app).
+- **Numbering**: zero-padded numeric prefixes (`001-…`, `002-…`); new migrations
+  start at the next free number. They sort lexicographically == numerically.
+- **Idempotency**: migrations must be safe to run against a DB that already has the
+  objects (e.g. a fresh install bootstrapped from `schema.sql`). MySQL lacks
+  `ADD COLUMN/CONSTRAINT IF NOT EXISTS`, so guard with `information_schema` lookups +
+  `PREPARE/EXECUTE` dynamic SQL (see `003-categories-and-page-category.sql`), or use
+  natively-idempotent forms (`CREATE TABLE IF NOT EXISTS`). The runner uses
+  `multipleStatements` so a file may contain several `;`-separated statements.
+- Migrations to date: `001` blueprint schema, `002` page SEO metadata,
+  `003` categories table + `pages.category_id` + `fk_pages_category` (closed a
+  schema/migration drift — `schema.sql` had them but no migration did),
+  `004` `UNIQUE(scope_key, version)` on `prompts` (dedupes first, then adds the key).
 
 ## Database Writes & Transactions
 

--- a/app/api/categories/sync/route.js
+++ b/app/api/categories/sync/route.js
@@ -1,6 +1,7 @@
-import pool from "@/lib/db";
+import pool, { withTransaction } from "@/lib/db";
 import mysql from "mysql2/promise";
 import { requireAuth } from "@/lib/auth";
+import { categoryLocalId } from "@/lib/categories";
 import { NextResponse } from "next/server";
 
 async function getExtConfig() {
@@ -9,7 +10,7 @@ async function getExtConfig() {
   return Object.fromEntries(rows.map(r => [r.config_key, r.config_value]));
 }
 
-const DEFAULT_L1 = "SELECT id, zh_tw_name AS name, slug, zh_tw_description AS description FROM categories ORDER BY id";
+const DEFAULT_L1 = "SELECT id, zh_tw_name AS name, slug, zh_tw_description AS description, display_order AS sort_order FROM categories ORDER BY id";
 const DEFAULT_L2 = `SELECT ct.category_id AS parent_id, t.id, t.zh_tw_name AS name, t.slug, t.zh_tw_description AS description, ct.is_primary, t.display_order
   FROM category_treatment ct JOIN treatments t ON ct.treatment_id = t.id ORDER BY ct.category_id, t.display_order`;
 
@@ -31,22 +32,30 @@ export async function POST(req) {
     const [l1Rows] = await ext.query(cfg.ext_db_query_l1 || DEFAULT_L1);
     const [l2Rows] = await ext.query(cfg.ext_db_query_l2 || DEFAULT_L2);
 
-    // Upsert L1 (external categories → local parent categories)
-    for (const r of l1Rows) {
-      await pool.query(
-        "INSERT INTO categories (id, name, slug, description, parent_id, sort_order) VALUES (?, ?, ?, ?, NULL, ?) ON DUPLICATE KEY UPDATE name=VALUES(name), slug=VALUES(slug), description=VALUES(description)",
-        [r.id, r.name, r.slug || `cat-${r.id}`, r.description || null, r.sort_order ?? 0]
-      );
-    }
+    // The whole sync is one transaction: a mid-loop FK failure (or an INT
+    // overflow guard throwing) rolls back every prior upsert rather than
+    // leaving the categories table half-synced. We do NOT delete categories
+    // that disappeared externally — that could orphan pages (captain's chosen
+    // default); externally-deleted categories are simply left in place.
+    await withTransaction(async (conn) => {
+      // Upsert L1 (external categories → local parent categories)
+      for (const r of l1Rows) {
+        await conn.query(
+          "INSERT INTO categories (id, name, slug, description, parent_id, sort_order) VALUES (?, ?, ?, ?, NULL, ?) ON DUPLICATE KEY UPDATE name=VALUES(name), slug=VALUES(slug), description=VALUES(description), sort_order=VALUES(sort_order)",
+          [r.id, r.name, r.slug || `cat-${r.id}`, r.description || null, r.sort_order ?? 0]
+        );
+      }
 
-    // Upsert L2 (treatments → local child categories, keyed by category_id * 100000 + treatment_id)
-    for (const r of l2Rows) {
-      const localId = r.parent_id * 100000 + r.id;
-      await pool.query(
-        "INSERT INTO categories (id, name, slug, description, parent_id, sort_order) VALUES (?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE name=VALUES(name), slug=VALUES(slug), description=VALUES(description), parent_id=VALUES(parent_id), sort_order=VALUES(sort_order)",
-        [localId, r.name, r.slug || `treat-${r.id}`, r.description || null, r.parent_id, r.display_order ?? 0]
-      );
-    }
+      // Upsert L2 (treatments → local child categories, keyed via categoryLocalId
+      // which guards against INT-overflow / sibling-range collisions).
+      for (const r of l2Rows) {
+        const localId = categoryLocalId(r.parent_id, r.id);
+        await conn.query(
+          "INSERT INTO categories (id, name, slug, description, parent_id, sort_order) VALUES (?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE name=VALUES(name), slug=VALUES(slug), description=VALUES(description), parent_id=VALUES(parent_id), sort_order=VALUES(sort_order)",
+          [localId, r.name, r.slug || `treat-${r.id}`, r.description || null, r.parent_id, r.display_order ?? 0]
+        );
+      }
+    });
 
     return NextResponse.json({ synced: { l1: l1Rows.length, l2: l2Rows.length } });
   } finally {

--- a/app/api/prompts/route.js
+++ b/app/api/prompts/route.js
@@ -1,4 +1,5 @@
-import pool from "@/lib/db";
+import pool, { withTransaction } from "@/lib/db";
+import { nextPromptVersion } from "@/lib/prompts";
 import { NextResponse } from "next/server";
 
 // GET /api/prompts?scope_key=xxx — get active + version history
@@ -18,26 +19,38 @@ export async function POST(req) {
   const { scope_type, scope_key, content } = await req.json();
   if (!scope_key || !scope_type) return NextResponse.json({ error: "scope_type and scope_key required" }, { status: 400 });
 
-  // Get next version number
-  const [maxRow] = await pool.query("SELECT COALESCE(MAX(version),0) as mv FROM prompts WHERE scope_key = ?", [scope_key]);
-  const nextVersion = maxRow[0].mv + 1;
+  // The next-version SELECT, the deactivate, and the insert must be atomic:
+  // concurrent saves would otherwise pick the same version (now blocked by the
+  // UNIQUE(scope_key, version) constraint) and leave multiple is_active rows
+  // (the active prompt drives every LLM call). FOR UPDATE serializes racing
+  // writers so the second one sees the first's new max.
+  const result = await withTransaction(async (conn) => {
+    const [maxRow] = await conn.query(
+      "SELECT COALESCE(MAX(version),0) as mv FROM prompts WHERE scope_key = ? FOR UPDATE",
+      [scope_key]
+    );
+    const nextVersion = nextPromptVersion(maxRow[0].mv);
 
-  // Deactivate old
-  await pool.query("UPDATE prompts SET is_active = 0 WHERE scope_key = ?", [scope_key]);
+    await conn.query("UPDATE prompts SET is_active = 0 WHERE scope_key = ?", [scope_key]);
 
-  // Insert new active version
-  const [r] = await pool.query(
-    "INSERT INTO prompts (scope_type, scope_key, version, content, is_active) VALUES (?, ?, ?, ?, 1)",
-    [scope_type, scope_key, nextVersion, content || ""]
-  );
+    const [r] = await conn.query(
+      "INSERT INTO prompts (scope_type, scope_key, version, content, is_active) VALUES (?, ?, ?, ?, 1)",
+      [scope_type, scope_key, nextVersion, content || ""]
+    );
+    return { id: r.insertId, version: nextVersion };
+  });
 
-  return NextResponse.json({ id: r.insertId, version: nextVersion }, { status: 201 });
+  return NextResponse.json(result, { status: 201 });
 }
 
 // PUT /api/prompts — activate a specific version
 export async function PUT(req) {
   const { scope_key, version } = await req.json();
-  await pool.query("UPDATE prompts SET is_active = 0 WHERE scope_key = ?", [scope_key]);
-  await pool.query("UPDATE prompts SET is_active = 1 WHERE scope_key = ? AND version = ?", [scope_key, version]);
+  // Deactivate-then-activate must be atomic, else a mid-sequence failure could
+  // leave the scope_key with zero active prompts.
+  await withTransaction(async (conn) => {
+    await conn.query("UPDATE prompts SET is_active = 0 WHERE scope_key = ?", [scope_key]);
+    await conn.query("UPDATE prompts SET is_active = 1 WHERE scope_key = ? AND version = ?", [scope_key, version]);
+  });
   return NextResponse.json({ ok: true });
 }

--- a/db/migrate.mjs
+++ b/db/migrate.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+// Migration runner: applies db/migrations/*.sql in filename order and records
+// each applied file in a `schema_migrations` table so it runs exactly once.
+//
+// This is what keeps db/schema.sql and db/migrations/ from drifting: schema.sql
+// is the from-scratch snapshot for fresh installs; every change to it MUST also
+// ship as a numbered, idempotent migration here so existing databases converge.
+//
+//   npm run migrate          # apply all pending migrations
+//   npm run migrate -- --status   # list applied / pending without applying
+//
+// Connection config comes from lib/db.js loadConfig() (env vars or
+// .db-config.json), exactly like the app.
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import mysql from "mysql2/promise";
+import { loadConfig } from "../lib/db.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MIGRATIONS_DIR = path.join(__dirname, "migrations");
+
+function listMigrationFiles() {
+  if (!fs.existsSync(MIGRATIONS_DIR)) return [];
+  return fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith(".sql"))
+    .sort(); // zero-padded numeric prefixes sort lexicographically == numerically
+}
+
+async function ensureMigrationsTable(conn) {
+  await conn.query(
+    `CREATE TABLE IF NOT EXISTS schema_migrations (
+       filename VARCHAR(255) PRIMARY KEY,
+       applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+     )`
+  );
+}
+
+async function appliedSet(conn) {
+  const [rows] = await conn.query("SELECT filename FROM schema_migrations");
+  return new Set(rows.map((r) => r.filename));
+}
+
+async function main() {
+  const statusOnly = process.argv.includes("--status");
+
+  const config = loadConfig();
+  if (!config) {
+    console.error(
+      "No DB config found. Set DB_HOST/DB_NAME (and friends) or create .db-config.json first."
+    );
+    process.exit(1);
+  }
+
+  // multipleStatements so a single migration file (which may contain several
+  // statements, incl. PREPARE/EXECUTE guards) runs as one query.
+  const conn = await mysql.createConnection({ ...config, multipleStatements: true });
+  try {
+    await ensureMigrationsTable(conn);
+    const applied = await appliedSet(conn);
+    const files = listMigrationFiles();
+    const pending = files.filter((f) => !applied.has(f));
+
+    if (statusOnly) {
+      console.log(`Migrations in ${MIGRATIONS_DIR}:`);
+      for (const f of files) console.log(`  ${applied.has(f) ? "[applied]" : "[pending]"} ${f}`);
+      if (!files.length) console.log("  (none)");
+      return;
+    }
+
+    if (!pending.length) {
+      console.log("No pending migrations. Database is up to date.");
+      return;
+    }
+
+    for (const file of pending) {
+      const sql = fs.readFileSync(path.join(MIGRATIONS_DIR, file), "utf-8");
+      process.stdout.write(`Applying ${file} ... `);
+      await conn.query(sql);
+      await conn.query("INSERT INTO schema_migrations (filename) VALUES (?)", [file]);
+      console.log("done");
+    }
+    console.log(`Applied ${pending.length} migration(s).`);
+  } finally {
+    await conn.end();
+  }
+}
+
+main().catch((err) => {
+  console.error("\nMigration failed:", err.message);
+  process.exit(1);
+});

--- a/db/migrations/003-categories-and-page-category.sql
+++ b/db/migrations/003-categories-and-page-category.sql
@@ -1,0 +1,38 @@
+-- Migration: Add categories table, pages.category_id, and the FK linking them.
+-- Fixes schema/migration drift: db/schema.sql already defined these but no
+-- migration created them. Written idempotently (information_schema guards +
+-- CREATE TABLE IF NOT EXISTS) so it is a no-op on databases — including fresh
+-- installs bootstrapped from schema.sql — that already have them.
+
+CREATE TABLE IF NOT EXISTS categories (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  slug VARCHAR(255) NOT NULL UNIQUE,
+  description TEXT,
+  parent_id INT DEFAULT NULL,
+  sort_order INT DEFAULT 0,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT fk_categories_parent FOREIGN KEY (parent_id) REFERENCES categories(id) ON DELETE CASCADE
+);
+
+-- Add pages.category_id only if the column is missing (MySQL lacks
+-- ADD COLUMN IF NOT EXISTS, so guard via information_schema + dynamic SQL).
+SET @col_exists := (
+  SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'pages' AND column_name = 'category_id'
+);
+SET @sql := IF(@col_exists = 0,
+  'ALTER TABLE pages ADD COLUMN category_id INT DEFAULT NULL',
+  'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- Add the FK only if it does not already exist.
+SET @fk_exists := (
+  SELECT COUNT(*) FROM information_schema.table_constraints
+  WHERE table_schema = DATABASE() AND table_name = 'pages'
+    AND constraint_name = 'fk_pages_category' AND constraint_type = 'FOREIGN KEY'
+);
+SET @sql := IF(@fk_exists = 0,
+  'ALTER TABLE pages ADD CONSTRAINT fk_pages_category FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE SET NULL',
+  'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/db/migrations/004-prompts-unique-version.sql
+++ b/db/migrations/004-prompts-unique-version.sql
@@ -1,0 +1,25 @@
+-- Migration: Enforce UNIQUE(scope_key, version) on prompts.
+-- Without it, concurrent saves could mint duplicate versions for the same
+-- scope_key. The POST /api/prompts handler now also runs the version sequence
+-- in a transaction; this constraint is the backstop that makes a racing insert
+-- fail loudly instead of silently duplicating.
+
+-- Defensively remove any pre-existing duplicate (scope_key, version) rows,
+-- keeping the highest id (most recent) of each group, so the constraint can be
+-- added on databases that already accumulated duplicates.
+DELETE p1 FROM prompts p1
+  INNER JOIN prompts p2
+    ON p1.scope_key = p2.scope_key
+   AND p1.version = p2.version
+   AND p1.id < p2.id;
+
+-- Add the unique key only if it does not already exist (idempotent).
+SET @idx_exists := (
+  SELECT COUNT(*) FROM information_schema.statistics
+  WHERE table_schema = DATABASE() AND table_name = 'prompts'
+    AND index_name = 'uniq_scope_version'
+);
+SET @sql := IF(@idx_exists = 0,
+  'ALTER TABLE prompts ADD UNIQUE KEY uniq_scope_version (scope_key, version)',
+  'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -104,7 +104,8 @@ CREATE TABLE IF NOT EXISTS prompts (
   content TEXT,
   is_active TINYINT(1) NOT NULL DEFAULT 1,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  INDEX idx_scope (scope_key, is_active)
+  INDEX idx_scope (scope_key, is_active),
+  UNIQUE KEY uniq_scope_version (scope_key, version)
 );
 
 CREATE TABLE IF NOT EXISTS users (

--- a/lib/categories.js
+++ b/lib/categories.js
@@ -1,0 +1,37 @@
+// Pure helpers for the external-category sync (no DB), so the local-id mapping
+// and its overflow guards are unit-testable independently of MySQL.
+
+// Max value of a signed MySQL INT column. Writing a larger value silently
+// clamps/wraps, which would corrupt the L2 id mapping.
+export const MYSQL_INT_MAX = 2147483647;
+
+// External L2 treatments are keyed locally as parent_id * MULTIPLIER + id so a
+// child category's local id encodes its parent. The multiplier bounds how many
+// treatments can share a parent before colliding into the next parent's range.
+export const L2_ID_MULTIPLIER = 100000;
+
+// Compute the local categories.id for an external L2 treatment from its parent
+// category id and its own id. Guards against:
+//   (a) treatment ids >= the multiplier, which would collide with a sibling
+//       parent's range (e.g. parent 1 / treatment 100000 == parent 2 / 0); and
+//   (b) results that overflow MySQL's signed INT (parent_id >= ~21475), which
+//       MySQL silently clamps — corrupting the mapping rather than erroring.
+// Throws a descriptive error instead of producing a corrupt key; the caller
+// runs inside a transaction, so the throw rolls the whole sync back.
+export function categoryLocalId(parentId, id) {
+  if (!Number.isInteger(parentId) || !Number.isInteger(id) || parentId < 0 || id < 0) {
+    throw new Error(`Invalid category ids: parent_id=${parentId}, id=${id}`);
+  }
+  if (id >= L2_ID_MULTIPLIER) {
+    throw new Error(
+      `Treatment id ${id} >= ${L2_ID_MULTIPLIER}; would collide with a sibling parent's id range`
+    );
+  }
+  const localId = parentId * L2_ID_MULTIPLIER + id;
+  if (localId > MYSQL_INT_MAX) {
+    throw new Error(
+      `Local category id ${localId} (parent_id=${parentId}, id=${id}) exceeds MySQL INT max ${MYSQL_INT_MAX}`
+    );
+  }
+  return localId;
+}

--- a/lib/categories.test.js
+++ b/lib/categories.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { categoryLocalId, MYSQL_INT_MAX, L2_ID_MULTIPLIER } from "./categories.js";
+
+describe("categoryLocalId", () => {
+  it("maps parent_id and id into a single key", () => {
+    expect(categoryLocalId(1, 42)).toBe(100042);
+    expect(categoryLocalId(0, 5)).toBe(5);
+    expect(categoryLocalId(20, 999)).toBe(2000999);
+  });
+
+  it("keeps sibling parents in disjoint ranges (no collision below the multiplier)", () => {
+    // parent 1's largest valid slot is below parent 2's smallest slot.
+    expect(categoryLocalId(1, L2_ID_MULTIPLIER - 1)).toBeLessThan(categoryLocalId(2, 0));
+  });
+
+  it("rejects treatment ids >= the multiplier (would collide with the next parent)", () => {
+    expect(() => categoryLocalId(1, L2_ID_MULTIPLIER)).toThrow(/collide/);
+    expect(() => categoryLocalId(1, L2_ID_MULTIPLIER + 1)).toThrow(/collide/);
+  });
+
+  it("accepts the largest parent_id that still fits in a signed INT", () => {
+    // parent_id * 100000 + id must stay <= 2147483647.
+    const maxParent = Math.floor((MYSQL_INT_MAX - 0) / L2_ID_MULTIPLIER); // 21474
+    expect(categoryLocalId(maxParent, 0)).toBeLessThanOrEqual(MYSQL_INT_MAX);
+  });
+
+  it("rejects results that overflow MySQL signed INT", () => {
+    // 21475 * 100000 = 2,147,500,000 > 2,147,483,647
+    expect(() => categoryLocalId(21475, 0)).toThrow(/exceeds MySQL INT max/);
+    // boundary: 21474 * 100000 + 99999 = 2,147,499,999 also overflows
+    expect(() => categoryLocalId(21474, 99999)).toThrow(/exceeds MySQL INT max/);
+  });
+
+  it("rejects negative or non-integer ids", () => {
+    expect(() => categoryLocalId(-1, 5)).toThrow(/Invalid category ids/);
+    expect(() => categoryLocalId(1, -5)).toThrow(/Invalid category ids/);
+    expect(() => categoryLocalId(1.5, 5)).toThrow(/Invalid category ids/);
+    expect(() => categoryLocalId(1, "5")).toThrow(/Invalid category ids/);
+  });
+});

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -1,0 +1,10 @@
+// Pure helpers for the prompt versioning system (no DB/React), so the
+// version-selection logic is unit-testable independently of MySQL.
+
+// Compute the next prompt version from the current max version for a scope_key.
+// `currentMax` is COALESCE(MAX(version), 0) — i.e. 0 when no versions exist yet.
+// Always returns a positive integer one greater than the current max.
+export function nextPromptVersion(currentMax) {
+  const max = Number.isFinite(currentMax) ? currentMax : 0;
+  return Math.max(0, Math.trunc(max)) + 1;
+}

--- a/lib/prompts.test.js
+++ b/lib/prompts.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { nextPromptVersion } from "./prompts.js";
+
+describe("nextPromptVersion", () => {
+  it("returns 1 when no versions exist (max 0)", () => {
+    expect(nextPromptVersion(0)).toBe(1);
+  });
+  it("increments the current max", () => {
+    expect(nextPromptVersion(1)).toBe(2);
+    expect(nextPromptVersion(7)).toBe(8);
+  });
+  it("treats null/undefined/NaN as no versions", () => {
+    expect(nextPromptVersion(null)).toBe(1);
+    expect(nextPromptVersion(undefined)).toBe(1);
+    expect(nextPromptVersion(NaN)).toBe(1);
+  });
+  it("never produces a non-positive version from junk input", () => {
+    expect(nextPromptVersion(-5)).toBe(1);
+  });
+  it("truncates fractional maxes", () => {
+    expect(nextPromptVersion(3.9)).toBe(4);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "migrate": "node db/migrate.mjs",
     "test": "vitest run"
   },
   "dependencies": {


### PR DESCRIPTION
Batch of DB-integrity fixes (grouped to avoid migration-number conflicts).

## Finding 2 — prompt versioning: non-atomic + no uniqueness
- Migration `004` adds `UNIQUE(scope_key, version)` to `prompts` (dedupes any existing duplicate rows first, keeping the highest id per group).
- `POST /api/prompts` now runs `MAX(version)+1 → deactivate → insert` inside `withTransaction` with `FOR UPDATE` on the max lookup, so concurrent saves can't mint duplicate versions or leave multiple `is_active` rows.
- `PUT /api/prompts` (deactivate → activate) is now atomic too.
- Pure `nextPromptVersion` extracted to `lib/prompts.js` with unit tests.

## Finding 3 — category sync: non-transactional + dead sort_order + INT overflow
- Whole L1/L2 upsert wrapped in `withTransaction` (rolls back on any mid-loop failure instead of half-syncing).
- `sort_order` added to `DEFAULT_L1` and now persisted on update.
- Raw `parent_id*100000+id` key replaced with `categoryLocalId` (`lib/categories.js`), which throws on sibling-range collisions and signed-INT overflow rather than writing a corrupt key. Unit-tested incl. boundaries.
- Reconciliation policy: externally-deleted categories are left in place (no auto-delete) to avoid orphaning pages.

## Finding 6 — schema/migration drift
- Migration `003` adds the `categories` table, `pages.category_id`, and `fk_pages_category` — idempotent via `information_schema` guards + `CREATE TABLE IF NOT EXISTS`, safe on DBs (incl. fresh installs from `schema.sql`) that already have them.
- New migration runner `db/migrate.mjs` + `npm run migrate` applies `db/migrations/*.sql` in order and tracks them in a `schema_migrations` table so schema.sql and migrations can't drift again (`npm run migrate -- --status` to inspect).
- `db/schema.sql` updated with the prompts unique key; `AGENT.md` documents the migration workflow.

## Validation
- `npm test` — 59 passing (8 files), incl. new `lib/prompts.test.js` and `lib/categories.test.js`.
- `npm run build` — exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
