### PR TITLE
Harden auth layer: stale pool ref, secureCookie mismatch, loose auth-exempt prefix

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -14,10 +14,12 @@ import { getToken } from "next-auth/jwt";
 import { NextResponse } from "next/server";
 import { isDbConfigured } from "@/lib/db";
 
-let pool;
+// Resolve lib/db's pool fresh on every call. lib/db memoizes it internally, so
+// this is free — and crucially it RESPECTS a runtime DB repoint: saveDbConfig()
+// (via /api/db-setup) nulls lib/db's pool, so a stale local cache here would keep
+// reading auth config from the OLD database after the rest of the app moved on.
 async function getPool() {
-  if (!pool) pool = (await import("@/lib/db")).getPool();
-  return pool;
+  return (await import("@/lib/db")).getPool();
 }
 
 export async function getConfig(key) {
@@ -82,9 +84,30 @@ export async function isOAuthConfigured() {
   return (await getAuthConfig()).configured;
 }
 
+// Default name NextAuth gives the session cookie on a secure (https) origin.
+const SECURE_SESSION_COOKIE = "__Secure-next-auth.session-token";
+
+/**
+ * Decide whether getToken() should look for the SECURE (__Secure-prefixed)
+ * session cookie. A reverse proxy advertises the original scheme via
+ * `x-forwarded-proto`; a direct-HTTPS deploy with no L7 proxy sends no such
+ * header, so we fall back to a second https signal — the request's own protocol
+ * where available (proxy/requireAuth path), or the presence of the secure cookie
+ * itself (getServerSession path, which has no request URL). Both gate paths MUST
+ * agree, otherwise getToken reads the wrong cookie name and a legitimate admin's
+ * /preview/* 404s even though the proxy admitted them.
+ */
+export function deriveSecureCookie({ forwardedProto = "", protocolFallback = "", hasSecureCookie = false } = {}) {
+  const proto = forwardedProto || protocolFallback || "";
+  if (proto.includes("https")) return true;
+  return !!hasSecureCookie;
+}
+
 function isSecureRequest(req) {
-  const proto = req.headers.get("x-forwarded-proto") || req.nextUrl?.protocol || "";
-  return proto.includes("https");
+  return deriveSecureCookie({
+    forwardedProto: req.headers.get("x-forwarded-proto") || "",
+    protocolFallback: req.nextUrl?.protocol || "",
+  });
 }
 
 async function getSessionEmail(req, secret) {
@@ -177,7 +200,10 @@ export async function getServerSession() {
   if (!configured) return { configured: false, allowed: false, email: null };
   const { cookies, headers } = await import("next/headers");
   const [cookieStore, hdrs] = await Promise.all([cookies(), headers()]);
-  const secureCookie = (hdrs.get("x-forwarded-proto") || "").includes("https");
+  const secureCookie = deriveSecureCookie({
+    forwardedProto: hdrs.get("x-forwarded-proto") || "",
+    hasSecureCookie: typeof cookieStore.has === "function" && cookieStore.has(SECURE_SESSION_COOKIE),
+  });
   const token = await getToken({ req: { cookies: cookieStore, headers: {} }, secret, secureCookie });
   const email = token?.email || null;
   return { configured: true, allowed: isEmailAllowed(email, allowedLogins), email };

--- a/proxy.js
+++ b/proxy.js
@@ -16,9 +16,11 @@ export const config = {
 export default async function proxy(req) {
   const { pathname } = req.nextUrl;
 
-  // NextAuth endpoints (sign-in, callbacks) and the public auth-status endpoint
-  // must stay reachable so the login flow can run.
-  if (pathname.startsWith("/api/auth")) return NextResponse.next();
+  // NextAuth endpoints (sign-in, callbacks) and the public auth-config endpoint
+  // must stay reachable so the login flow can run. Match on a path BOUNDARY, not
+  // a loose prefix, so a future sibling like /api/authenticate is not silently
+  // exempted from the gate.
+  if (pathname === "/api/auth" || pathname.startsWith("/api/auth/")) return NextResponse.next();
 
   const { configured, ok } = await authorizeRequest(req);
   if (!configured || ok) return NextResponse.next();

--- a/test/authHardening.test.js
+++ b/test/authHardening.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock lib/db so lib/auth's dynamic `import("@/lib/db")` resolves to a fake we
+// can repoint between calls (simulating a runtime DB switch via saveDbConfig()).
+vi.mock("@/lib/db", () => ({
+  getPool: vi.fn(),
+  isDbConfigured: vi.fn(() => true),
+}));
+
+import { getConfig, deriveSecureCookie } from "@/lib/auth";
+import * as db from "@/lib/db";
+
+beforeEach(() => {
+  db.getPool.mockReset();
+});
+
+// F1: lib/auth must NOT cache the pool locally. saveDbConfig() nulls lib/db's
+// pool on a runtime DB repoint; if lib/auth held a stale reference it would keep
+// reading auth config from the OLD database. Each getConfig() must re-resolve.
+describe("getConfig — pool is not cached locally (F1)", () => {
+  it("picks up a repointed db pool on the next call", async () => {
+    const poolA = { query: vi.fn(async () => [[{ config_value: "A" }]]) };
+    const poolB = { query: vi.fn(async () => [[{ config_value: "B" }]]) };
+
+    db.getPool.mockReturnValue(poolA);
+    expect(await getConfig("nextauth_secret")).toBe("A");
+
+    // DB repointed: lib/db now hands out a different pool.
+    db.getPool.mockReturnValue(poolB);
+    expect(await getConfig("nextauth_secret")).toBe("B");
+
+    expect(db.getPool).toHaveBeenCalledTimes(2);
+    expect(poolB.query).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-resolves the pool on every call (no stale memo)", async () => {
+    const pool = { query: vi.fn(async () => [[{ config_value: "x" }]]) };
+    db.getPool.mockReturnValue(pool);
+    await getConfig("a");
+    await getConfig("b");
+    await getConfig("c");
+    expect(db.getPool).toHaveBeenCalledTimes(3);
+  });
+});
+
+// F2: proxy/requireAuth (via isSecureRequest) and getServerSession must derive
+// the same secureCookie flag, so getToken reads the same cookie name on both
+// paths. The shared helper takes whichever https signal each caller has.
+describe("deriveSecureCookie — shared https derivation (F2)", () => {
+  it("is secure when x-forwarded-proto is https (proxied deploy)", () => {
+    expect(deriveSecureCookie({ forwardedProto: "https" })).toBe(true);
+  });
+
+  it("is insecure when x-forwarded-proto is http", () => {
+    expect(deriveSecureCookie({ forwardedProto: "http" })).toBe(false);
+  });
+
+  // The proxy/requireAuth path: no proxy header, but the request URL is https.
+  it("falls back to the request protocol (direct-HTTPS, requireAuth path)", () => {
+    expect(deriveSecureCookie({ forwardedProto: "", protocolFallback: "https:" })).toBe(true);
+  });
+
+  // The getServerSession path: no proxy header and no request URL, but the
+  // browser presented the __Secure- session cookie → the origin is https.
+  it("falls back to the secure-cookie presence (direct-HTTPS, getServerSession path)", () => {
+    expect(deriveSecureCookie({ forwardedProto: "", hasSecureCookie: true })).toBe(true);
+  });
+
+  it("is insecure with no https signal at all", () => {
+    expect(deriveSecureCookie({})).toBe(false);
+    expect(deriveSecureCookie({ forwardedProto: "", protocolFallback: "http:", hasSecureCookie: false })).toBe(false);
+  });
+});


### PR DESCRIPTION
Three LOW-severity auth-layer robustness fixes (deep-sweep review, `data/review-glow-s3/report.md`). No change to the gate's authorization semantics.

## F1 (real bug) — stale DB pool reference
`lib/auth.js` cached lib/db's pool locally. A runtime DB repoint via `saveDbConfig()` (`/api/db-setup`) nulls lib/db's pool, but the stale local cache kept auth reading config from the OLD database. Fixed by re-resolving the (already-memoized) pool on each call so the reset is respected.

## F2 — secureCookie derivation mismatch
`getServerSession` derived `secureCookie` from `x-forwarded-proto` only, while `proxy`/`requireAuth` also fall back to the request protocol. On a direct-HTTPS deploy with no L7 proxy the two disagreed → `getToken` read the wrong cookie name and a legit admin's `/preview/*` 404'd. Both paths now go through a shared `deriveSecureCookie()` helper; `getServerSession` falls back to the presence of the `__Secure-` session cookie.

## F3 (hardening) — loose auth-exempt prefix
`proxy.js` used `startsWith("/api/auth")`, which would silently exempt a future `/api/authenticate`. Tightened to a path-boundary match. No current route affected.

## Tests
Added `test/authHardening.test.js`: F1 (pool not cached / re-resolved each call) and F2 (secureCookie fallbacks for both gate paths).

`npm run build` exit 0; `npm test` 79 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)