### PR TITLE
Make migrations 001/002 idempotent; add migration-runner idempotency test

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -317,7 +317,10 @@ as a numbered migration**, and vice-versa.
   `PREPARE/EXECUTE` dynamic SQL (see `003-categories-and-page-category.sql`), or use
   natively-idempotent forms (`CREATE TABLE IF NOT EXISTS`). The runner uses
   `multipleStatements` so a file may contain several `;`-separated statements.
-- Migrations to date: `001` blueprint schema, `002` page SEO metadata,
+  `db/migrate.test.js` enforces this: it fails on any unguarded `ALTER TABLE`,
+  any unguarded conditional DDL, or a bare `CREATE TABLE`, and verifies the
+  runner applies each file once and re-runs as a clean no-op.
+- Migrations to date (all idempotent): `001` blueprint schema, `002` page SEO metadata,
   `003` categories table + `pages.category_id` + `fk_pages_category` (closed a
   schema/migration drift — `schema.sql` had them but no migration did),
   `004` `UNIQUE(scope_key, version)` on `prompts` (dedupes first, then adds the key).

--- a/db/migrate.mjs
+++ b/db/migrate.mjs
@@ -6,6 +6,15 @@
 // is the from-scratch snapshot for fresh installs; every change to it MUST also
 // ship as a numbered, idempotent migration here so existing databases converge.
 //
+// Two layers of idempotency make re-running safe:
+//   1. schema_migrations records every applied filename, so a file is never
+//      applied twice in the same database.
+//   2. Each migration's SQL is itself idempotent (information_schema guards,
+//      CREATE TABLE IF NOT EXISTS, dynamic ADD COLUMN/CONSTRAINT). This is what
+//      lets the runner be pointed at a fresh install bootstrapped from
+//      schema.sql — where the objects already exist but schema_migrations is
+//      empty — without erroring on "duplicate column"/"table exists".
+//
 //   npm run migrate          # apply all pending migrations
 //   npm run migrate -- --status   # list applied / pending without applying
 //
@@ -21,7 +30,7 @@ import { loadConfig } from "../lib/db.js";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const MIGRATIONS_DIR = path.join(__dirname, "migrations");
 
-function listMigrationFiles() {
+export function listMigrationFiles() {
   if (!fs.existsSync(MIGRATIONS_DIR)) return [];
   return fs
     .readdirSync(MIGRATIONS_DIR)
@@ -43,6 +52,40 @@ async function appliedSet(conn) {
   return new Set(rows.map((r) => r.filename));
 }
 
+// Apply every pending migration exactly once, recording each in
+// schema_migrations. Returns { applied, pending } describing what was run (or,
+// in statusOnly mode, what is still pending). Pure with respect to its `conn`
+// argument so tests can drive it with a fake connection.
+export async function runMigrations(conn, { statusOnly = false, log = () => {} } = {}) {
+  await ensureMigrationsTable(conn);
+  const applied = await appliedSet(conn);
+  const files = listMigrationFiles();
+  const pending = files.filter((f) => !applied.has(f));
+
+  if (statusOnly) {
+    log(`Migrations in ${MIGRATIONS_DIR}:`);
+    for (const f of files) log(`  ${applied.has(f) ? "[applied]" : "[pending]"} ${f}`);
+    if (!files.length) log("  (none)");
+    return { applied: [], pending };
+  }
+
+  if (!pending.length) {
+    log("No pending migrations. Database is up to date.");
+    return { applied: [], pending: [] };
+  }
+
+  const done = [];
+  for (const file of pending) {
+    const sql = fs.readFileSync(path.join(MIGRATIONS_DIR, file), "utf-8");
+    log(`Applying ${file} ... `);
+    await conn.query(sql);
+    await conn.query("INSERT INTO schema_migrations (filename) VALUES (?)", [file]);
+    done.push(file);
+  }
+  log(`Applied ${done.length} migration(s).`);
+  return { applied: done, pending: [] };
+}
+
 async function main() {
   const statusOnly = process.argv.includes("--status");
 
@@ -58,37 +101,17 @@ async function main() {
   // statements, incl. PREPARE/EXECUTE guards) runs as one query.
   const conn = await mysql.createConnection({ ...config, multipleStatements: true });
   try {
-    await ensureMigrationsTable(conn);
-    const applied = await appliedSet(conn);
-    const files = listMigrationFiles();
-    const pending = files.filter((f) => !applied.has(f));
-
-    if (statusOnly) {
-      console.log(`Migrations in ${MIGRATIONS_DIR}:`);
-      for (const f of files) console.log(`  ${applied.has(f) ? "[applied]" : "[pending]"} ${f}`);
-      if (!files.length) console.log("  (none)");
-      return;
-    }
-
-    if (!pending.length) {
-      console.log("No pending migrations. Database is up to date.");
-      return;
-    }
-
-    for (const file of pending) {
-      const sql = fs.readFileSync(path.join(MIGRATIONS_DIR, file), "utf-8");
-      process.stdout.write(`Applying ${file} ... `);
-      await conn.query(sql);
-      await conn.query("INSERT INTO schema_migrations (filename) VALUES (?)", [file]);
-      console.log("done");
-    }
-    console.log(`Applied ${pending.length} migration(s).`);
+    await runMigrations(conn, { statusOnly, log: (m) => console.log(m) });
   } finally {
     await conn.end();
   }
 }
 
-main().catch((err) => {
-  console.error("\nMigration failed:", err.message);
-  process.exit(1);
-});
+// Only run as a CLI when invoked directly (node db/migrate.mjs), not when this
+// module is imported (e.g. by tests).
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main().catch((err) => {
+    console.error("\nMigration failed:", err.message);
+    process.exit(1);
+  });
+}

--- a/db/migrate.test.js
+++ b/db/migrate.test.js
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+import { listMigrationFiles, runMigrations } from "./migrate.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MIGRATIONS_DIR = path.join(__dirname, "migrations");
+
+function readMigration(file) {
+  return fs.readFileSync(path.join(MIGRATIONS_DIR, file), "utf-8");
+}
+
+// Strip line comments so guard/keyword checks ignore prose in comments.
+function stripComments(sql) {
+  return sql
+    .split("\n")
+    .map((line) => line.replace(/--.*$/, ""))
+    .join("\n");
+}
+
+describe("migration SQL is idempotent", () => {
+  const files = listMigrationFiles();
+
+  it("ships migration files", () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  for (const file of listMigrationFiles()) {
+    describe(file, () => {
+      const sql = stripComments(readMigration(file));
+
+      // The runner is pointed at fresh installs bootstrapped from schema.sql,
+      // where the objects already exist but schema_migrations is empty. A bare
+      // `ALTER TABLE ... ADD COLUMN/CONSTRAINT` would then error on "duplicate
+      // column"/"table exists". Idempotent migrations wrap every conditional
+      // DDL inside dynamic SQL (`IF(@col_exists = 0, 'ALTER TABLE ...', ...)`),
+      // so no statement should *start* with ALTER TABLE outside a quoted string.
+      it("has no unguarded ALTER TABLE statement", () => {
+        const offending = sql
+          .split("\n")
+          .map((l) => l.trim())
+          .filter((l) => /^ALTER\s+TABLE/i.test(l));
+        expect(offending).toEqual([]);
+      });
+
+      it("guards every conditional DDL with an existence check", () => {
+        // If the file performs an ADD COLUMN / ADD CONSTRAINT (even inside
+        // dynamic SQL), it must consult information_schema to decide whether to.
+        if (/ADD\s+COLUMN|ADD\s+CONSTRAINT/i.test(sql)) {
+          expect(/information_schema/i.test(sql)).toBe(true);
+        }
+      });
+
+      it("creates tables only with IF NOT EXISTS", () => {
+        const creates = sql.match(/CREATE\s+TABLE(\s+IF\s+NOT\s+EXISTS)?/gi) || [];
+        for (const c of creates) {
+          expect(c.replace(/\s+/g, " ").toUpperCase()).toBe("CREATE TABLE IF NOT EXISTS");
+        }
+      });
+    });
+  }
+});
+
+// A fake MySQL connection that models just enough of schema_migrations to drive
+// the runner: it remembers which filenames have been recorded and records every
+// migration-body query it executes, so a test can assert the runner applies each
+// file exactly once and a re-run is a clean no-op.
+function makeFakeDb() {
+  const appliedFilenames = [];
+  const migrationQueries = [];
+  const conn = {
+    async query(sql, params) {
+      const s = String(sql);
+      if (/CREATE TABLE IF NOT EXISTS schema_migrations/i.test(s)) return [[], []];
+      if (/SELECT filename FROM schema_migrations/i.test(s)) {
+        return [appliedFilenames.map((f) => ({ filename: f })), []];
+      }
+      if (/INSERT INTO schema_migrations/i.test(s)) {
+        appliedFilenames.push(params[0]);
+        return [{ affectedRows: 1 }, []];
+      }
+      // Anything else is a migration body being applied.
+      migrationQueries.push(s);
+      return [[], []];
+    },
+  };
+  return { conn, appliedFilenames, migrationQueries };
+}
+
+describe("runMigrations is idempotent across runs", () => {
+  it("applies every migration once, then re-runs as a clean no-op", async () => {
+    const files = listMigrationFiles();
+    const { conn, appliedFilenames, migrationQueries } = makeFakeDb();
+
+    // First run: nothing applied yet, so all migrations run in order.
+    const first = await runMigrations(conn);
+    expect(first.applied).toEqual(files);
+    expect(first.pending).toEqual([]);
+    expect(appliedFilenames).toEqual(files);
+    // Exactly one body query per migration file.
+    expect(migrationQueries.length).toBe(files.length);
+
+    const queriesAfterFirst = migrationQueries.length;
+
+    // Second run: every file already recorded -> no body queries, no inserts.
+    const second = await runMigrations(conn);
+    expect(second.applied).toEqual([]);
+    expect(second.pending).toEqual([]);
+    expect(migrationQueries.length).toBe(queriesAfterFirst);
+    expect(appliedFilenames).toEqual(files);
+  });
+
+  it("--status never applies anything and reports all pending on a fresh DB", async () => {
+    const files = listMigrationFiles();
+    const { conn, appliedFilenames, migrationQueries } = makeFakeDb();
+
+    const res = await runMigrations(conn, { statusOnly: true });
+    expect(res.applied).toEqual([]);
+    expect(res.pending).toEqual(files);
+    expect(migrationQueries.length).toBe(0);
+    expect(appliedFilenames).toEqual([]);
+  });
+});

--- a/db/migrations/001-blueprint-schema.sql
+++ b/db/migrations/001-blueprint-schema.sql
@@ -1,11 +1,52 @@
 -- Migration: Add blueprint support to page_templates
 -- Issue #27
+--
+-- Written idempotently (information_schema guards + CREATE TABLE IF NOT EXISTS +
+-- dynamic SQL for conditional ADD COLUMN/ADD CONSTRAINT, since MySQL lacks
+-- ADD COLUMN/CONSTRAINT IF NOT EXISTS) so it is a no-op on databases — including
+-- fresh installs bootstrapped from db/schema.sql — that already have these.
 
-ALTER TABLE page_templates
-  ADD COLUMN header_id INT DEFAULT NULL,
-  ADD COLUMN footer_id INT DEFAULT NULL,
-  ADD CONSTRAINT fk_pt_header FOREIGN KEY (header_id) REFERENCES headers(id) ON DELETE SET NULL,
-  ADD CONSTRAINT fk_pt_footer FOREIGN KEY (footer_id) REFERENCES footers(id) ON DELETE SET NULL;
+-- Add page_templates.header_id only if the column is missing.
+SET @col_exists := (
+  SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'page_templates' AND column_name = 'header_id'
+);
+SET @sql := IF(@col_exists = 0,
+  'ALTER TABLE page_templates ADD COLUMN header_id INT DEFAULT NULL',
+  'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- Add page_templates.footer_id only if the column is missing.
+SET @col_exists := (
+  SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'page_templates' AND column_name = 'footer_id'
+);
+SET @sql := IF(@col_exists = 0,
+  'ALTER TABLE page_templates ADD COLUMN footer_id INT DEFAULT NULL',
+  'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- Add the header FK only if it does not already exist.
+SET @fk_exists := (
+  SELECT COUNT(*) FROM information_schema.table_constraints
+  WHERE table_schema = DATABASE() AND table_name = 'page_templates'
+    AND constraint_name = 'fk_pt_header' AND constraint_type = 'FOREIGN KEY'
+);
+SET @sql := IF(@fk_exists = 0,
+  'ALTER TABLE page_templates ADD CONSTRAINT fk_pt_header FOREIGN KEY (header_id) REFERENCES headers(id) ON DELETE SET NULL',
+  'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- Add the footer FK only if it does not already exist.
+SET @fk_exists := (
+  SELECT COUNT(*) FROM information_schema.table_constraints
+  WHERE table_schema = DATABASE() AND table_name = 'page_templates'
+    AND constraint_name = 'fk_pt_footer' AND constraint_type = 'FOREIGN KEY'
+);
+SET @sql := IF(@fk_exists = 0,
+  'ALTER TABLE page_templates ADD CONSTRAINT fk_pt_footer FOREIGN KEY (footer_id) REFERENCES footers(id) ON DELETE SET NULL',
+  'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
 CREATE TABLE IF NOT EXISTS page_template_sections (
   id INT AUTO_INCREMENT PRIMARY KEY,

--- a/db/migrations/002-page-seo-metadata.sql
+++ b/db/migrations/002-page-seo-metadata.sql
@@ -1,8 +1,47 @@
 -- Migration: Add per-page SEO metadata columns
 -- Issue #88
+--
+-- Written idempotently (information_schema guards + dynamic SQL for conditional
+-- ADD COLUMN, since MySQL lacks ADD COLUMN IF NOT EXISTS) so it is a no-op on
+-- databases — including fresh installs bootstrapped from db/schema.sql — that
+-- already have these columns.
 
-ALTER TABLE pages
-  ADD COLUMN meta_title VARCHAR(255) DEFAULT NULL,
-  ADD COLUMN meta_description TEXT DEFAULT NULL,
-  ADD COLUMN og_image VARCHAR(1024) DEFAULT NULL,
-  ADD COLUMN canonical VARCHAR(1024) DEFAULT NULL;
+-- Add pages.meta_title only if the column is missing.
+SET @col_exists := (
+  SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'pages' AND column_name = 'meta_title'
+);
+SET @sql := IF(@col_exists = 0,
+  'ALTER TABLE pages ADD COLUMN meta_title VARCHAR(255) DEFAULT NULL',
+  'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- Add pages.meta_description only if the column is missing.
+SET @col_exists := (
+  SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'pages' AND column_name = 'meta_description'
+);
+SET @sql := IF(@col_exists = 0,
+  'ALTER TABLE pages ADD COLUMN meta_description TEXT DEFAULT NULL',
+  'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- Add pages.og_image only if the column is missing.
+SET @col_exists := (
+  SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'pages' AND column_name = 'og_image'
+);
+SET @sql := IF(@col_exists = 0,
+  'ALTER TABLE pages ADD COLUMN og_image VARCHAR(1024) DEFAULT NULL',
+  'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- Add pages.canonical only if the column is missing.
+SET @col_exists := (
+  SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'pages' AND column_name = 'canonical'
+);
+SET @sql := IF(@col_exists = 0,
+  'ALTER TABLE pages ADD COLUMN canonical VARCHAR(1024) DEFAULT NULL',
+  'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
## Problem
The migration runner `db/migrate.mjs` applies `db/migrations/*.sql` in order, but `001-blueprint-schema.sql` and `002-page-seo-metadata.sql` used bare `ALTER TABLE ... ADD COLUMN`/`ADD CONSTRAINT`. Those error with "duplicate column"/"duplicate key" when run against a DB that already has the objects — e.g. a fresh install bootstrapped from `db/schema.sql` (which already contains them all). A failure on 001/002 also blocked 003/004 from applying.

## Fix
- **001**: guard `page_templates.header_id`/`footer_id` column adds and the `fk_pt_header`/`fk_pt_footer` FKs with `information_schema` checks + dynamic SQL (same pattern as `003`); `page_template_sections` already used `CREATE TABLE IF NOT EXISTS`.
- **002**: guard each of the four `pages` SEO column adds (`meta_title`, `meta_description`, `og_image`, `canonical`) the same way.
- **migrate.mjs**: extract `runMigrations()`/`listMigrationFiles()` so they're importable; only run the CLI when invoked directly.
- **db/migrate.test.js** (the top coverage gap the review flagged): static checks that every migration is idempotent (no unguarded `ALTER TABLE`, conditional DDL guarded via `information_schema`, `CREATE TABLE` only with `IF NOT EXISTS`) plus a runner test that applies each file once and re-runs as a clean no-op.

No disposable MySQL was available in this environment, so end-to-end safety is enforced via the static SQL guards + the runner no-op test rather than a live double-apply.

## Verification
- `npm run build` → exit 0
- `npm test` → 105 passed (12 files), including the new `db/migrate.test.js` (15 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)