### PR TITLE
Add durable unit tests for page assembly, LLM provider parsing, and category-sync rollback

### DIFF
--- a/app/api/categories/sync/route.test.js
+++ b/app/api/categories/sync/route.test.js
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import mysql from "mysql2/promise";
+
+// The category sync wraps every L1/L2 upsert in withTransaction so that a
+// mid-loop failure (an FK violation, or the categoryLocalId overflow guard
+// throwing) rolls the whole table back rather than leaving it half-synced.
+// We mock mysql2 so the REAL withTransaction and REAL categoryLocalId run
+// against an in-memory connection — only the wire I/O is faked. createPool
+// backs lib/db's pool (getExtConfig + the transaction connection); the route
+// also opens an external connection via createConnection for the source rows.
+vi.mock("mysql2/promise", () => ({
+  default: { createPool: vi.fn(), createConnection: vi.fn() },
+}));
+vi.mock("@/lib/auth", () => ({ requireAuth: vi.fn().mockResolvedValue(null) }));
+vi.mock("next/server", () => ({
+  NextResponse: { json: (body, init) => ({ body, status: init?.status ?? 200 }) },
+}));
+
+import { POST } from "./route.js";
+
+const EXT_CONFIG = [
+  { config_key: "ext_db_host", config_value: "ext-host" },
+  { config_key: "ext_db_name", config_value: "ext-db" },
+  { config_key: "ext_db_user", config_value: "u" },
+  { config_key: "ext_db_password", config_value: "p" },
+  { config_key: "ext_db_port", config_value: "3306" },
+];
+
+// The local pool is created once and cached inside lib/db; reuse a stable object
+// and just reconfigure its vi.fns each test. getConnection hands out a fresh
+// transaction connection recorded in `conn`.
+const pool = { query: vi.fn(), getConnection: vi.fn() };
+const ext = { query: vi.fn(), end: vi.fn().mockResolvedValue(undefined) };
+let conn;
+
+function makeConn() {
+  return {
+    beginTransaction: vi.fn().mockResolvedValue(undefined),
+    commit: vi.fn().mockResolvedValue(undefined),
+    rollback: vi.fn().mockResolvedValue(undefined),
+    release: vi.fn(),
+    query: vi.fn().mockResolvedValue([[], []]),
+  };
+}
+
+beforeEach(() => {
+  process.env.DB_HOST = "localhost";
+  process.env.DB_NAME = "test";
+
+  pool.query.mockReset();
+  pool.query.mockImplementation(async (sql) => {
+    if (sql.includes("system_config")) return [EXT_CONFIG];
+    return [[]];
+  });
+  pool.getConnection.mockReset();
+  pool.getConnection.mockImplementation(async () => {
+    conn = makeConn();
+    return conn;
+  });
+
+  ext.query.mockReset();
+  ext.end.mockClear();
+
+  mysql.createPool.mockReset();
+  mysql.createConnection.mockReset();
+  mysql.createPool.mockReturnValue(pool);
+  mysql.createConnection.mockResolvedValue(ext);
+});
+
+describe("POST /api/categories/sync — transaction success", () => {
+  it("commits and reports the synced counts when every upsert succeeds", async () => {
+    ext.query
+      .mockResolvedValueOnce([[{ id: 1, name: "Skin", slug: "skin", sort_order: 0 }]]) // L1
+      .mockResolvedValueOnce([[{ parent_id: 1, id: 5, name: "Peel", slug: "peel", display_order: 0 }]]); // L2
+
+    const res = await POST({ json: async () => ({}) });
+
+    expect(res.status).toBe(200);
+    expect(res.body.synced).toEqual({ l1: 1, l2: 1 });
+    expect(conn.commit).toHaveBeenCalledTimes(1);
+    expect(conn.rollback).not.toHaveBeenCalled();
+    expect(conn.release).toHaveBeenCalledTimes(1);
+    expect(ext.end).toHaveBeenCalledTimes(1);
+    // L2 child is keyed via categoryLocalId(1, 5) = 100005.
+    const l2Insert = conn.query.mock.calls.find((c) => c[1] && c[1][0] === 100005);
+    expect(l2Insert).toBeTruthy();
+  });
+});
+
+describe("POST /api/categories/sync — rollback on mid-loop failure", () => {
+  it("rolls back the whole sync when a child insert violates the FK", async () => {
+    ext.query
+      .mockResolvedValueOnce([[{ id: 1, name: "Skin", slug: "skin", sort_order: 0 }]]) // L1
+      .mockResolvedValueOnce([
+        [
+          { parent_id: 1, id: 5, name: "Peel", slug: "peel", display_order: 0 },
+          // parent_id 999 has no matching L1 row -> the FK insert fails mid-loop.
+          { parent_id: 999, id: 7, name: "Orphan", slug: "orphan", display_order: 1 },
+        ],
+      ]); // L2
+
+    pool.getConnection.mockImplementation(async () => {
+      conn = makeConn();
+      conn.query.mockImplementation(async (sql, params) => {
+        // The L2 insert binds parent_id at index 4; simulate ER_NO_REFERENCED_ROW_2.
+        if (sql.includes("INSERT") && params && params[4] === 999) {
+          throw new Error("ER_NO_REFERENCED_ROW_2");
+        }
+        return [[], []];
+      });
+      return conn;
+    });
+
+    // The route has no catch around withTransaction, so the error propagates
+    // after the transaction is rolled back and the external conn is closed.
+    await expect(POST({ json: async () => ({}) })).rejects.toThrow("ER_NO_REFERENCED_ROW_2");
+
+    expect(conn.beginTransaction).toHaveBeenCalledTimes(1);
+    expect(conn.rollback).toHaveBeenCalledTimes(1);
+    expect(conn.commit).not.toHaveBeenCalled(); // table left unchanged
+    expect(conn.release).toHaveBeenCalledTimes(1);
+    expect(ext.end).toHaveBeenCalledTimes(1); // finally still closes the source conn
+  });
+
+  it("rolls back when the categoryLocalId overflow guard throws inside the loop", async () => {
+    ext.query
+      .mockResolvedValueOnce([[{ id: 1, name: "Skin", slug: "skin", sort_order: 0 }]]) // L1
+      .mockResolvedValueOnce([
+        // treatment id >= L2_ID_MULTIPLIER -> categoryLocalId throws before any query.
+        [{ parent_id: 1, id: 100000, name: "Bad", slug: "bad", display_order: 0 }],
+      ]); // L2
+
+    await expect(POST({ json: async () => ({}) })).rejects.toThrow(/collide/);
+
+    expect(conn.rollback).toHaveBeenCalledTimes(1);
+    expect(conn.commit).not.toHaveBeenCalled();
+    expect(conn.release).toHaveBeenCalledTimes(1);
+    expect(ext.end).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("POST /api/categories/sync — preconditions", () => {
+  it("returns 400 and never opens the external connection when not configured", async () => {
+    pool.query.mockImplementation(async () => [[]]); // no ext_db_host / ext_db_name
+    const res = await POST({ json: async () => ({}) });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/not configured/);
+    expect(mysql.createConnection).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/generate/route.test.js
+++ b/app/api/generate/route.test.js
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// The generate route normalizes each provider's wire shape into
+// { rawText, truncated, model } and then applies the shared empty-guard /
+// fence-strip / truncation checks. These tests drive the real POST handler with
+// the provider SDKs, DB, and auth all stubbed — no network, no MySQL — to lock
+// in the per-provider response parsing for the well-formed, fenced, empty/
+// refused, and truncated cases.
+
+const { query, sdk } = vi.hoisted(() => ({
+  query: vi.fn(),
+  sdk: {
+    openaiCreate: vi.fn(),
+    claudeCreate: vi.fn(),
+    geminiGenerate: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/db", () => ({ default: { query } }));
+vi.mock("@/lib/auth", () => ({ requireAuth: vi.fn().mockResolvedValue(null) }));
+vi.mock("next/server", () => ({
+  NextResponse: { json: (body, init) => ({ body, status: init?.status ?? 200 }) },
+}));
+
+vi.mock("openai", () => ({
+  default: class {
+    constructor() {
+      this.chat = { completions: { create: sdk.openaiCreate } };
+    }
+  },
+}));
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: class {
+    constructor() {
+      this.messages = { create: sdk.claudeCreate };
+    }
+  },
+}));
+vi.mock("@google/generative-ai", () => ({
+  GoogleGenerativeAI: class {
+    getGenerativeModel() {
+      return { generateContent: sdk.geminiGenerate };
+    }
+  },
+}));
+
+import { POST } from "./route.js";
+
+function makeReq(body) {
+  return { json: async () => body };
+}
+
+beforeEach(() => {
+  query.mockReset();
+  // A configured API key for getKey(); a prompt row for the system scope; an
+  // empty result set for the generation_logs INSERT.
+  query.mockImplementation(async (sql) => {
+    if (sql.includes("system_config")) return [[{ config_value: "test-key" }]];
+    if (sql.includes("FROM prompts")) return [[{ id: 1, version: 2, content: "sys" }]];
+    return [[]];
+  });
+  sdk.openaiCreate.mockReset();
+  sdk.claudeCreate.mockReset();
+  sdk.geminiGenerate.mockReset();
+});
+
+// --- OpenAI -----------------------------------------------------------------
+
+describe("POST /api/generate — OpenAI response parsing", () => {
+  it("returns the HTML from a well-formed completion", async () => {
+    sdk.openaiCreate.mockResolvedValue({
+      choices: [{ message: { content: "<div>ok</div>" }, finish_reason: "stop" }],
+    });
+    const res = await POST(makeReq({ provider: "openai", prompt: "go" }));
+    expect(res.status).toBe(200);
+    expect(res.body.html).toBe("<div>ok</div>");
+  });
+
+  it("strips a markdown code fence the model wrapped around the HTML", async () => {
+    sdk.openaiCreate.mockResolvedValue({
+      choices: [{ message: { content: "```html\n<div>ok</div>\n```" }, finish_reason: "stop" }],
+    });
+    const res = await POST(makeReq({ provider: "openai", prompt: "go" }));
+    expect(res.body.html).toBe("<div>ok</div>");
+  });
+
+  it("returns 500 when the completion is null (content-filtered / refused)", async () => {
+    sdk.openaiCreate.mockResolvedValue({
+      choices: [{ message: { content: null }, finish_reason: "content_filter" }],
+    });
+    const res = await POST(makeReq({ provider: "openai", prompt: "go" }));
+    expect(res.status).toBe(500);
+    expect(res.body.error).toMatch(/empty response/);
+  });
+
+  it("returns 502 when the output was truncated at the token budget", async () => {
+    sdk.openaiCreate.mockResolvedValue({
+      choices: [{ message: { content: "<div>partial" }, finish_reason: "length" }],
+    });
+    const res = await POST(makeReq({ provider: "openai", prompt: "go" }));
+    expect(res.status).toBe(502);
+    expect(res.body.truncated).toBe(true);
+    expect(res.body.error).toMatch(/truncated/);
+  });
+});
+
+// --- Claude -----------------------------------------------------------------
+
+describe("POST /api/generate — Claude response parsing", () => {
+  it("returns the HTML from a well-formed message", async () => {
+    sdk.claudeCreate.mockResolvedValue({
+      content: [{ type: "text", text: "<p>hi</p>" }],
+      stop_reason: "end_turn",
+    });
+    const res = await POST(makeReq({ provider: "claude", prompt: "go" }));
+    expect(res.body.html).toBe("<p>hi</p>");
+  });
+
+  it("picks the first text block when a non-text block leads the content array", async () => {
+    sdk.claudeCreate.mockResolvedValue({
+      content: [{ type: "thinking", thinking: "..." }, { type: "text", text: "<p>hi</p>" }],
+      stop_reason: "end_turn",
+    });
+    const res = await POST(makeReq({ provider: "claude", prompt: "go" }));
+    expect(res.body.html).toBe("<p>hi</p>");
+  });
+
+  it("returns 500 when there is no text block (refused)", async () => {
+    sdk.claudeCreate.mockResolvedValue({ content: [], stop_reason: "end_turn" });
+    const res = await POST(makeReq({ provider: "claude", prompt: "go" }));
+    expect(res.status).toBe(500);
+    expect(res.body.error).toMatch(/empty response/);
+  });
+
+  it("returns 502 when stop_reason is max_tokens", async () => {
+    sdk.claudeCreate.mockResolvedValue({
+      content: [{ type: "text", text: "<p>partial" }],
+      stop_reason: "max_tokens",
+    });
+    const res = await POST(makeReq({ provider: "claude", prompt: "go" }));
+    expect(res.status).toBe(502);
+    expect(res.body.truncated).toBe(true);
+  });
+});
+
+// --- Gemini -----------------------------------------------------------------
+
+describe("POST /api/generate — Gemini response parsing", () => {
+  it("returns the HTML from a well-formed candidate", async () => {
+    sdk.geminiGenerate.mockResolvedValue({
+      response: { text: () => "<section>x</section>", candidates: [{ finishReason: "STOP" }] },
+    });
+    const res = await POST(makeReq({ provider: "gemini", prompt: "go" }));
+    expect(res.body.html).toBe("<section>x</section>");
+  });
+
+  it("returns 500 when .text() throws (blocked candidate)", async () => {
+    sdk.geminiGenerate.mockResolvedValue({
+      response: {
+        text: () => {
+          throw new Error("blocked");
+        },
+        candidates: [{ finishReason: "SAFETY" }],
+      },
+    });
+    const res = await POST(makeReq({ provider: "gemini", prompt: "go" }));
+    expect(res.status).toBe(500);
+    expect(res.body.error).toMatch(/empty response/);
+  });
+
+  it("returns 502 when finishReason is MAX_TOKENS", async () => {
+    sdk.geminiGenerate.mockResolvedValue({
+      response: { text: () => "<section>partial", candidates: [{ finishReason: "MAX_TOKENS" }] },
+    });
+    const res = await POST(makeReq({ provider: "gemini", prompt: "go" }));
+    expect(res.status).toBe(502);
+    expect(res.body.truncated).toBe(true);
+  });
+});
+
+// --- request guards & logging ----------------------------------------------
+
+describe("POST /api/generate — request guards and logging", () => {
+  it("returns 400 when the prompt is missing", async () => {
+    const res = await POST(makeReq({ provider: "openai" }));
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Prompt required/);
+  });
+
+  it("returns 400 when no API key is configured for the provider", async () => {
+    query.mockImplementation(async (sql) => {
+      if (sql.includes("system_config")) return [[]]; // no key row
+      return [[]];
+    });
+    const res = await POST(makeReq({ provider: "openai", prompt: "go" }));
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/No API key/);
+  });
+
+  it("persists the cleaned HTML to generation_logs on success", async () => {
+    sdk.openaiCreate.mockResolvedValue({
+      choices: [{ message: { content: "```html\n<div>ok</div>\n```" }, finish_reason: "stop" }],
+    });
+    await POST(makeReq({ provider: "openai", prompt: "go" }));
+    const logCall = query.mock.calls.find((c) => c[0].includes("generation_logs"));
+    expect(logCall).toBeTruthy();
+    // response_html is the last bound parameter; it stores the fence-stripped HTML.
+    expect(logCall[1][logCall[1].length - 1]).toBe("<div>ok</div>");
+  });
+
+  it("does not write a log row when the completion is empty", async () => {
+    sdk.openaiCreate.mockResolvedValue({
+      choices: [{ message: { content: "" }, finish_reason: "stop" }],
+    });
+    await POST(makeReq({ provider: "openai", prompt: "go" }));
+    const logCall = query.mock.calls.find((c) => c[0].includes("generation_logs"));
+    expect(logCall).toBeUndefined();
+  });
+});

--- a/lib/pages.test.js
+++ b/lib/pages.test.js
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// getPageBySlug is the core public-page builder. These tests exercise its
+// assembly logic — section ordering, {{content}} injection, the two-pass
+// variable substitution + stripUnresolved boundary, and missing-page/section
+// behavior — against a mocked DB layer (injected fake rows, no live MySQL).
+
+const { query } = vi.hoisted(() => ({ query: vi.fn() }));
+vi.mock("@/lib/db", () => ({ default: { query } }));
+
+// Route each pool.query() call to the rows a given test wants. content_path is
+// checked before the generic site_config branch because getContentPath's SQL
+// mentions both "site_config" and "content_path".
+function setupDb({ pages = [], sections = [], config = [], contentPath } = {}) {
+  query.mockImplementation(async (sql) => {
+    if (sql.includes("content_path")) {
+      return [contentPath !== undefined ? [{ config_value: contentPath }] : []];
+    }
+    if (sql.includes("FROM pages")) return [pages];
+    if (sql.includes("FROM sections")) return [sections];
+    if (sql.includes("FROM site_config")) return [config];
+    return [[]];
+  });
+}
+
+let pages;
+beforeEach(async () => {
+  // Reset module state between tests so getSiteConfig's 10s in-memory cache from
+  // one test never leaks its config into the next.
+  vi.resetModules();
+  query.mockReset();
+  pages = await import("./pages.js");
+});
+
+describe("getPageBySlug — missing page / section behavior", () => {
+  it("returns null when no page matches the slug", async () => {
+    setupDb({ pages: [] });
+    expect(await pages.getPageBySlug("nope")).toBeNull();
+  });
+
+  it("does not query sections when the page is missing", async () => {
+    setupDb({ pages: [] });
+    await pages.getPageBySlug("nope");
+    const sectionQueried = query.mock.calls.some((c) => c[0].includes("FROM sections"));
+    expect(sectionQueried).toBe(false);
+  });
+
+  it("renders an empty {{content}} when the page has no sections", async () => {
+    setupDb({
+      pages: [{ id: 7, slug: "bare", template_content: "<main>{{content}}</main>" }],
+      sections: [],
+      config: [],
+    });
+    const page = await pages.getPageBySlug("bare");
+    expect(page.sections).toEqual([]);
+    expect(page.body_content).toBe("<main></main>");
+  });
+
+  it("scopes the published filter into the page query", async () => {
+    setupDb({ pages: [{ id: 1, slug: "x" }], sections: [], config: [] });
+    await pages.getPageBySlug("x", true);
+    const pageSql = query.mock.calls.find((c) => c[0].includes("FROM pages"))[0];
+    expect(pageSql).toContain("p.status = 'published'");
+
+    query.mockClear();
+    setupDb({ pages: [{ id: 1, slug: "x" }], sections: [], config: [] });
+    await pages.getPageBySlug("x", false);
+    const draftSql = query.mock.calls.find((c) => c[0].includes("FROM pages"))[0];
+    expect(draftSql).not.toContain("p.status = 'published'");
+  });
+});
+
+describe("getPageBySlug — section ordering and {{content}} injection", () => {
+  it("joins section content in row order, separated by newlines", async () => {
+    setupDb({
+      pages: [{ id: 1, slug: "p", template_content: "{{content}}" }],
+      sections: [
+        { id: 1, content: "A", variables: null },
+        { id: 2, content: "B", variables: null },
+        { id: 3, content: "C", variables: null },
+      ],
+      config: [],
+    });
+    const page = await pages.getPageBySlug("p");
+    expect(page.body_content).toBe("A\nB\nC");
+  });
+
+  it("defaults to a bare {{content}} template when the page has no template", async () => {
+    setupDb({
+      pages: [{ id: 1, slug: "p", template_content: null }],
+      sections: [{ id: 1, content: "<h1>Hi</h1>", variables: null }],
+      config: [],
+    });
+    const page = await pages.getPageBySlug("p");
+    expect(page.body_content).toBe("<h1>Hi</h1>");
+  });
+
+  it("fills every {{content}} placeholder, not just the first", async () => {
+    setupDb({
+      pages: [{ id: 1, slug: "p", template_content: "{{content}}|{{content}}" }],
+      sections: [{ id: 1, content: "X", variables: null }],
+      config: [],
+    });
+    const page = await pages.getPageBySlug("p");
+    expect(page.body_content).toBe("X|X");
+  });
+
+  it("injects $-sequences in section HTML literally (no replace-pattern interpretation)", async () => {
+    setupDb({
+      pages: [{ id: 1, slug: "p", template_content: "<div>{{content}}</div>" }],
+      sections: [{ id: 1, content: "price $$5 and $& and $1", variables: null }],
+      config: [],
+    });
+    const page = await pages.getPageBySlug("p");
+    expect(page.body_content).toBe("<div>price $$5 and $& and $1</div>");
+  });
+});
+
+describe("getPageBySlug — two-pass substitution + stripUnresolved boundary", () => {
+  it("resolves section vars in pass one, then config in pass two", async () => {
+    setupDb({
+      pages: [{ id: 1, slug: "p", template_content: "{{content}}" }],
+      sections: [{ id: 1, content: "{{a}}-{{site}}", variables: { a: "1" } }],
+      config: [{ config_key: "site", config_value: "2" }],
+    });
+    const page = await pages.getPageBySlug("p");
+    // pass 1 resolves {{a}} from section vars -> "1-{{site}}"; pass 2 resolves
+    // {{site}} from config -> "1-2".
+    expect(page.sections[0].content).toBe("1-2");
+    expect(page.body_content).toBe("1-2");
+  });
+
+  it("parses section variables supplied as a JSON string", async () => {
+    setupDb({
+      pages: [{ id: 1, slug: "p", template_content: "{{content}}" }],
+      sections: [{ id: 1, content: "{{a}}", variables: '{"a":"json"}' }],
+      config: [],
+    });
+    const page = await pages.getPageBySlug("p");
+    expect(page.sections[0].content).toBe("json");
+  });
+
+  it("strips variables left unresolved after both passes", async () => {
+    setupDb({
+      pages: [{ id: 1, slug: "p", template_content: "{{content}}" }],
+      sections: [{ id: 1, content: "[{{gone}}]", variables: {} }],
+      config: [],
+    });
+    const page = await pages.getPageBySlug("p");
+    // {{gone}} is in neither section vars nor config, so the stripUnresolved
+    // second pass removes it rather than leaking a literal placeholder.
+    expect(page.sections[0].content).toBe("[]");
+  });
+
+  it("substitutes and strips header/footer content from config", async () => {
+    setupDb({
+      pages: [
+        {
+          id: 1,
+          slug: "p",
+          template_content: "{{content}}",
+          header_content: "<h>{{brand}}{{missing}}</h>",
+          footer_content: "<f>{{brand}}</f>",
+        },
+      ],
+      sections: [],
+      config: [{ config_key: "brand", config_value: "Glow" }],
+    });
+    const page = await pages.getPageBySlug("p");
+    expect(page.header_content).toBe("<h>Glow</h>");
+    expect(page.footer_content).toBe("<f>Glow</f>");
+  });
+
+  it("leaves null header/footer content untouched", async () => {
+    setupDb({
+      pages: [{ id: 1, slug: "p", template_content: "{{content}}", header_content: null, footer_content: null }],
+      sections: [],
+      config: [],
+    });
+    const page = await pages.getPageBySlug("p");
+    expect(page.header_content).toBeNull();
+    expect(page.footer_content).toBeNull();
+  });
+});
+
+describe("getContentPath", () => {
+  it("normalizes a bare prefix to a leading slash", async () => {
+    setupDb({ contentPath: "blog" });
+    expect(await pages.getContentPath()).toBe("/blog");
+  });
+
+  it("preserves an already-absolute prefix", async () => {
+    setupDb({ contentPath: "/blog" });
+    expect(await pages.getContentPath()).toBe("/blog");
+  });
+
+  it("treats empty and root values as no prefix", async () => {
+    setupDb({ contentPath: "" });
+    expect(await pages.getContentPath()).toBe("");
+    setupDb({ contentPath: "/" });
+    expect(await pages.getContentPath()).toBe("");
+  });
+
+  it("returns no prefix when the config row is absent", async () => {
+    setupDb({});
+    expect(await pages.getContentPath()).toBe("");
+  });
+});
+
+describe("resolvePageSlug", () => {
+  it("joins segments when there is no content path", () => {
+    expect(pages.resolvePageSlug(["a", "b"], "")).toBe("a/b");
+  });
+
+  it("returns null for an empty slug with no content path", () => {
+    expect(pages.resolvePageSlug([], "")).toBeNull();
+  });
+
+  it("strips the content path prefix", () => {
+    expect(pages.resolvePageSlug(["blog", "a", "b"], "/blog")).toBe("a/b");
+  });
+
+  it("returns null when the URL bare-matches the prefix with nothing after it", () => {
+    expect(pages.resolvePageSlug(["blog"], "/blog")).toBeNull();
+  });
+
+  it("returns null when the URL does not start with the configured prefix", () => {
+    expect(pages.resolvePageSlug(["other", "x"], "/blog")).toBeNull();
+  });
+});


### PR DESCRIPTION
Fills the highest-value remaining test gaps flagged by review sweeps. All tests are deterministic and DB-free (mock `lib/db`, the mysql2 connections, and the provider SDKs). No production code changed — no testability seams were needed.

## What's covered
- **`lib/pages.test.js` — `getPageBySlug` assembly:** section ordering/join, `{{content}}` injection (`replaceAll` + literal `$`-sequence preservation), the two-pass variable substitution + `stripUnresolved` boundary, header/footer substitution, missing-page / missing-section behavior, and `getContentPath`/`resolvePageSlug` content-path prefix handling.
- **`app/api/generate/route.test.js` — provider response parsing:** OpenAI / Claude / Gemini response shapes (well-formed, fenced, empty/null/refused, truncated) routed through the `cleanGeneratedHtml` / `stripCodeFences` / truncation guards, plus the request guards (missing prompt, no API key) and the generation-log persistence path.
- **`app/api/categories/sync/route.test.js` — transaction/rollback:** exercises the real `withTransaction` + real `categoryLocalId` over a mocked connection — commit on success, rollback (and no commit) on a mid-loop FK failure and on the `categoryLocalId` overflow guard throwing, plus the not-configured precondition.

## Validation
- `npm run build` → exit 0 (compiled successfully)
- `npm test` → 146 passed (was 105; +41 new tests across 3 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)