### PR TITLE
Fix admin lockout: accept comma-separated allow-list in isEmailAllowed

### DIFF
--- a/app/api/system-config/route.js
+++ b/app/api/system-config/route.js
@@ -1,6 +1,6 @@
 import pool from "@/lib/db";
 import { saveDbConfig } from "@/lib/db";
-import { requireAuth } from "@/lib/auth";
+import { requireAuth, parseAllowedLogins } from "@/lib/auth";
 import { NextResponse } from "next/server";
 
 const SECRET_KEYS = ["aws_access_key", "aws_secret_key", "db_password", "google_client_secret", "nextauth_secret", "openai_api_key", "claude_api_key", "gemini_api_key", "ext_db_password"];
@@ -61,7 +61,11 @@ export async function PUT(req) {
     if (key in DB_KEYS) {
       dbFields[key] = value;
     } else {
-      await pool.query("INSERT INTO system_config (config_key, config_value) VALUES (?, ?) ON DUPLICATE KEY UPDATE config_value=?", [key, value, value]);
+      // Canonicalize the allow-list on save: accept commas and/or newlines on
+      // input but store one entry per line, so the persisted value matches the
+      // "one per line" UI hint and isEmailAllowed parses it identically.
+      const stored = key === "allowed_logins" ? parseAllowedLogins(value).join("\n") : value;
+      await pool.query("INSERT INTO system_config (config_key, config_value) VALUES (?, ?) ON DUPLICATE KEY UPDATE config_value=?", [key, stored, stored]);
     }
   }
 

--- a/app/cms-admin/system-config/page.js
+++ b/app/cms-admin/system-config/page.js
@@ -22,7 +22,7 @@ const sections = [
     { key: "google_client_secret", label: "Client Secret", secret: true },
     { key: "nextauth_secret", label: "NextAuth Secret", secret: true },
   ]},
-  { title: "Login Restrictions", desc: "Allowed emails and domains (one per line). e.g. watson@google.com or @glow360.com. Leave empty to allow all.", fields: [
+  { title: "Login Restrictions", desc: "Allowed emails and domains, one per line or comma-separated. e.g. watson@google.com or @glow360.com. Leave empty to allow all.", fields: [
     { key: "allowed_logins", label: "Allowed Logins", multiline: true },
   ]},
   { title: "LLM API Keys", desc: "API keys for AI language models.", fields: [

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -30,18 +30,24 @@ export async function getConfig(key) {
 }
 
 /**
- * Decide whether `email` is permitted by the newline-separated `allowedLogins`
- * allow-list. FAILS CLOSED: an empty/blank allow-list denies everyone, so a
- * fresh OAuth setup cannot silently grant admin to any Google account.
+ * Decide whether `email` is permitted by the `allowedLogins` allow-list. Entries
+ * may be separated by newlines and/or commas (a comma-pasted list is a common way
+ * to enter the allow-list, so accepting both prevents a silent total lockout).
+ * FAILS CLOSED: an empty/blank allow-list denies everyone, so a fresh OAuth setup
+ * cannot silently grant admin to any Google account.
  *
  * Rules are case-insensitive. A rule beginning with "@" matches any address in
  * that domain (suffix match); any other rule is an exact-address match.
  */
-export function isEmailAllowed(email, allowedLogins) {
-  const rules = (allowedLogins || "")
-    .split("\n")
+export function parseAllowedLogins(allowedLogins) {
+  return (allowedLogins || "")
+    .split(/[\n,]+/)
     .map(s => s.trim().toLowerCase())
     .filter(Boolean);
+}
+
+export function isEmailAllowed(email, allowedLogins) {
+  const rules = parseAllowedLogins(allowedLogins);
   if (!rules.length) return false; // fail closed: no allow-list entries → deny
   if (!email) return false;
   const lower = email.toLowerCase();

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isEmailAllowed } from "@/lib/auth";
+import { isEmailAllowed, parseAllowedLogins } from "@/lib/auth";
 
 describe("isEmailAllowed", () => {
   // S8: an empty/blank allow-list must FAIL CLOSED (deny), never grant any
@@ -51,5 +51,62 @@ describe("isEmailAllowed", () => {
   it("ignores blank lines and surrounding whitespace within the list", () => {
     const rules = "\n   admin@pro360.com.tw  \n\n";
     expect(isEmailAllowed("admin@pro360.com.tw", rules)).toBe(true);
+  });
+
+  // Regression: a comma-pasted allow-list must not collapse into one unmatchable
+  // rule and fail-closed-lock-out every admin. The captain's real list is the
+  // comma-separated form below.
+  it("accepts a comma-separated allow-list (the real captain's list)", () => {
+    const rules = "@pro360.com.tw,watsonyu@gmail.com,glow360app@gmail.com";
+    expect(isEmailAllowed("anyone@pro360.com.tw", rules)).toBe(true);
+    expect(isEmailAllowed("watsonyu@gmail.com", rules)).toBe(true);
+    expect(isEmailAllowed("glow360app@gmail.com", rules)).toBe(true);
+    expect(isEmailAllowed("attacker@evil.com", rules)).toBe(false);
+  });
+
+  it("accepts a comma-separated list with surrounding spaces", () => {
+    const rules = "admin@pro360.com.tw, ops@vendor.io ,  ceo@pro360.com.tw";
+    expect(isEmailAllowed("admin@pro360.com.tw", rules)).toBe(true);
+    expect(isEmailAllowed("ops@vendor.io", rules)).toBe(true);
+    expect(isEmailAllowed("ceo@pro360.com.tw", rules)).toBe(true);
+    expect(isEmailAllowed("nope@pro360.com.tw", rules)).toBe(false);
+  });
+
+  it("accepts @domain rules inside a comma-separated list", () => {
+    const rules = "@pro360.com.tw, @partner.example, ops@vendor.io";
+    expect(isEmailAllowed("someone@pro360.com.tw", rules)).toBe(true);
+    expect(isEmailAllowed("anybody@partner.example", rules)).toBe(true);
+    expect(isEmailAllowed("ops@vendor.io", rules)).toBe(true);
+    expect(isEmailAllowed("nobody@evil.com", rules)).toBe(false);
+  });
+
+  it("accepts a mix of commas and newlines as separators", () => {
+    const rules = "@pro360.com.tw,watsonyu@gmail.com\nglow360app@gmail.com\nops@vendor.io, ceo@pro360.com.tw";
+    expect(isEmailAllowed("hi@pro360.com.tw", rules)).toBe(true);
+    expect(isEmailAllowed("watsonyu@gmail.com", rules)).toBe(true);
+    expect(isEmailAllowed("glow360app@gmail.com", rules)).toBe(true);
+    expect(isEmailAllowed("ops@vendor.io", rules)).toBe(true);
+    expect(isEmailAllowed("ceo@pro360.com.tw", rules)).toBe(true);
+    expect(isEmailAllowed("attacker@evil.com", rules)).toBe(false);
+  });
+
+  it("still fails closed when the list is only separators/whitespace", () => {
+    expect(isEmailAllowed("anyone@gmail.com", ",")).toBe(false);
+    expect(isEmailAllowed("anyone@gmail.com", " , , \n , ")).toBe(false);
+    expect(isEmailAllowed("admin@pro360.com.tw", ",,,")).toBe(false);
+  });
+});
+
+describe("parseAllowedLogins", () => {
+  it("splits on commas and newlines, trims, lowercases, drops empties", () => {
+    expect(parseAllowedLogins("@pro360.com.tw, Watson@Gmail.com\n\n ops@vendor.io ,"))
+      .toEqual(["@pro360.com.tw", "watson@gmail.com", "ops@vendor.io"]);
+  });
+
+  it("returns an empty array for blank or separator-only input", () => {
+    expect(parseAllowedLogins("")).toEqual([]);
+    expect(parseAllowedLogins(null)).toEqual([]);
+    expect(parseAllowedLogins(undefined)).toEqual([]);
+    expect(parseAllowedLogins(" , \n , ")).toEqual([]);
   });
 });


### PR DESCRIPTION
isEmailAllowed split allowed_logins only on "\n", so a comma-separated
allow-list (a common way to enter it, e.g.
"@pro360.com.tw,watsonyu@gmail.com,glow360app@gmail.com") collapsed into a
single rule that matches no real address. Combined with the correct
fail-closed-on-empty behavior, this silently locked out every admin once
OAuth was configured.

Split on both commas and newlines (/[\n,]+/) via a shared parseAllowedLogins
helper; keep trim, drop-empties, lowercase, fail-closed-on-empty, and the
case-insensitive + @domain-suffix + exact-match semantics. The nextauth
sign-in callback already routes through isEmailAllowed, so it is covered too.

Normalize the allow-list on save (system-config PUT) to canonical
newline-separated form using the same parser, and update the UI hint to say
commas are accepted. Extend the auth test suite with comma/newline/mixed/
spaced/@domain cases plus the separator-only-still-denies case.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
