### PR TITLE
Add npm run db:init: one-command from-scratch database setup

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -305,6 +305,19 @@ All styles in `app/globals.css`. Key classes:
 databases. These two must never drift: **every change to `schema.sql` must also ship
 as a numbered migration**, and vice-versa.
 
+- **First-time setup**: `npm run db:init` (`db/init.mjs`) is THE way to initialize a
+  database. It applies `schema.sql` and then runs all migrations, so a fresh DB ends
+  fully up to date in **one command**. This exists because `npm run migrate` alone on
+  an empty DB fails confusingly — migration `001` is an `ALTER TABLE page_templates`
+  that assumes the table exists, which it only does after `schema.sql` has run. Use
+  `db:init` to create; use `migrate` to upgrade an already-initialized DB. `db:init`
+  is idempotent (schema uses `CREATE TABLE IF NOT EXISTS` + `WHERE NOT EXISTS`/`ON
+  DUPLICATE KEY` seeds; migrations are recorded in `schema_migrations`), so re-running
+  it is a clean no-op. It connects directly to the configured `DB_NAME` and strips the
+  leading `CREATE DATABASE`/`USE glow_cms` lines from `schema.sql` (`stripSchemaPreamble`),
+  so it works even when the DB user can't `CREATE DATABASE` or the database is named
+  something other than `glow_cms`. `db/init.test.js` covers the strip logic, schema-then-
+  migrations ordering, and double-run idempotency.
 - **Runner**: `npm run migrate` (`db/migrate.mjs`) applies `db/migrations/*.sql` in
   filename order and records each in a `schema_migrations` table so each file runs
   exactly once. `npm run migrate -- --status` lists applied/pending without applying.

--- a/README.md
+++ b/README.md
@@ -54,13 +54,26 @@ DB_PORT=3306
 
 ### 3. Set up the database
 
-Run the checked-in bootstrap schema:
+Initialize the database with the single front-door command:
 
 ```bash
-mysql -u root -p < db/schema.sql
+npm run db:init                       # uses env vars / .db-config.json
+# or, loading a dotenv file explicitly:
+node --env-file=.env.local db/init.mjs
 ```
 
-`db/schema.sql` creates the `glow_cms` database and all 11 application tables, including `users` and `generation_logs`, which are required by the admin UI.
+`npm run db:init` applies `db/schema.sql` (the from-scratch snapshot — all 11
+application tables, including `users` and `generation_logs` required by the admin
+UI) and then runs all pending migrations, so the database ends fully up to date in
+one step. It is idempotent: re-running it on an already-initialized database is a
+clean no-op. Use this for **first-time setup**; use `npm run migrate` to **upgrade**
+an already-initialized database.
+
+It connects directly to the configured database (`DB_NAME`), so it works even when
+your DB user can't `CREATE DATABASE` — the `CREATE DATABASE`/`USE` lines at the top
+of `db/schema.sql` are stripped automatically. (The raw `mysql -u root -p <
+db/schema.sql` path still works if you'd rather have the schema create the database
+itself, but then you must also run `npm run migrate`.)
 
 ### 4. Run
 

--- a/db/init.mjs
+++ b/db/init.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+// Database initializer: the ONE command that takes a brand-new database to fully
+// up to date. It applies db/schema.sql (the from-scratch snapshot) and then runs
+// the migration runner (db/migrate.mjs), in that order, against the configured DB.
+//
+// Why this exists: `npm run migrate` alone on an empty database fails confusingly
+// — migration 001 is an `ALTER TABLE page_templates ...` that assumes the table
+// already exists, which it only does after schema.sql has been applied. The fix
+// is not "make migrate create tables" (it stays an upgrade tool) but to provide a
+// single front door for first-time setup:
+//
+//   npm run db:init          # schema.sql, then all migrations -> DB fully ready
+//
+// Idempotent and safe to re-run. schema.sql uses CREATE TABLE IF NOT EXISTS and
+// WHERE NOT EXISTS / ON DUPLICATE KEY seeds; migrations are guarded and recorded
+// in schema_migrations. So on an already-initialized DB this is a clean no-op.
+//
+// Connection config comes from lib/db.js loadConfig() (env vars or
+// .db-config.json), exactly like the app and the migrator. For Node scripts you
+// can also pass `--env-file=.env.local`.
+//
+// schema.sql opens with `CREATE DATABASE IF NOT EXISTS glow_cms;` / `USE
+// glow_cms;`. When connecting directly to an existing database (the common case:
+// a managed DB whose name differs from glow_cms, or a user who can't CREATE
+// DATABASE), those lines are wrong — we already hold a connection to the target
+// schema. So we strip them and let the connection's own `database` decide where
+// the objects land. See stripSchemaPreamble().
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import mysql from "mysql2/promise";
+import { loadConfig } from "../lib/db.js";
+import { runMigrations } from "./migrate.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCHEMA_PATH = path.join(__dirname, "schema.sql");
+
+// Remove the leading `CREATE DATABASE ...` and `USE ...` statements from the
+// schema snapshot so it can be applied over an already-open connection to the
+// target database — whatever that database is named, and even when the
+// connecting user lacks CREATE DATABASE privilege. Every other statement is
+// returned unchanged. Pure string function so it can be unit-tested without a DB.
+export function stripSchemaPreamble(sql) {
+  // Split on top-level semicolons. schema.sql contains no stored
+  // routines/triggers/DELIMITER, so a naive `;` split is correct here.
+  return sql
+    .split(";")
+    .map((stmt) => stmt.trim())
+    .filter(Boolean)
+    .filter((stmt) => !/^CREATE\s+DATABASE\b/i.test(stmt))
+    .filter((stmt) => !/^USE\b/i.test(stmt))
+    .map((stmt) => stmt + ";")
+    .join("\n");
+}
+
+// Apply the schema snapshot (preamble stripped) over an existing connection.
+// `conn` must have multipleStatements enabled. Returns the SQL that was run.
+export async function applySchema(conn, schemaSql) {
+  const sql = stripSchemaPreamble(schemaSql);
+  if (sql.trim()) await conn.query(sql);
+  return sql;
+}
+
+// Full initialization against a live connection: schema first, then migrations.
+// Pure with respect to its `conn` argument so it can be driven by a fake DB in
+// tests. Returns what the migration runner reports.
+export async function initDatabase(conn, { log = () => {} } = {}) {
+  const schemaSql = fs.readFileSync(SCHEMA_PATH, "utf-8");
+  log("Applying db/schema.sql (from-scratch snapshot) ...");
+  await applySchema(conn, schemaSql);
+  log("Schema applied. Running migrations ...");
+  return runMigrations(conn, { log });
+}
+
+async function main() {
+  const config = loadConfig();
+  if (!config) {
+    console.error(
+      "No DB config found. Set DB_HOST/DB_NAME (and friends) or create .db-config.json first.\n" +
+        "Tip: node --env-file=.env.local db/init.mjs"
+    );
+    process.exit(1);
+  }
+
+  const conn = await mysql.createConnection({ ...config, multipleStatements: true });
+  try {
+    const { applied } = await initDatabase(conn, { log: (m) => console.log(m) });
+    if (applied.length) {
+      console.log(`\nDatabase initialized: schema applied, ${applied.length} migration(s) run.`);
+    } else {
+      console.log("\nDatabase already initialized — schema and migrations are up to date (no-op).");
+    }
+  } finally {
+    await conn.end();
+  }
+}
+
+// Only run as a CLI when invoked directly (node db/init.mjs), not when imported
+// (e.g. by tests).
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main().catch((err) => {
+    console.error("\nDatabase init failed:", err.message);
+    process.exit(1);
+  });
+}

--- a/db/init.test.js
+++ b/db/init.test.js
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+import { stripSchemaPreamble, applySchema, initDatabase } from "./init.mjs";
+import { listMigrationFiles } from "./migrate.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCHEMA_PATH = path.join(__dirname, "schema.sql");
+const schemaSql = fs.readFileSync(SCHEMA_PATH, "utf-8");
+
+describe("stripSchemaPreamble", () => {
+  it("removes the leading CREATE DATABASE and USE statements", () => {
+    const out = stripSchemaPreamble(schemaSql);
+    expect(/CREATE\s+DATABASE/i.test(out)).toBe(false);
+    // `USE glow_cms;` must be gone, but column/table bodies are untouched.
+    expect(/^\s*USE\s+/im.test(out)).toBe(false);
+  });
+
+  it("keeps the actual schema objects and seeds", () => {
+    const out = stripSchemaPreamble(schemaSql);
+    expect(/CREATE\s+TABLE\s+IF\s+NOT\s+EXISTS\s+page_templates/i.test(out)).toBe(true);
+    expect(/INSERT\s+INTO\s+page_templates/i.test(out)).toBe(true);
+  });
+
+  it("is a no-op for SQL that has no preamble", () => {
+    const sql = "CREATE TABLE IF NOT EXISTS t (id INT);";
+    expect(stripSchemaPreamble(sql).trim()).toBe("CREATE TABLE IF NOT EXISTS t (id INT);");
+  });
+
+  it("does not strip non-leading USE-prefixed identifiers", () => {
+    // A column or table whose name merely starts with "use" must survive.
+    const sql = "CREATE TABLE users (id INT);\nUSE other_db;";
+    const out = stripSchemaPreamble(sql);
+    expect(/CREATE\s+TABLE\s+users/i.test(out)).toBe(true);
+    expect(/^\s*USE\s+other_db/im.test(out)).toBe(false);
+  });
+});
+
+// A fake MySQL connection that records every query and models just enough of
+// schema_migrations for the migration runner. Lets us assert init's ordering
+// (schema before migrations) and idempotency without a live database.
+function makeFakeDb() {
+  const applied = [];
+  const queries = [];
+  const conn = {
+    async query(sql, params) {
+      const s = String(sql);
+      if (/CREATE TABLE IF NOT EXISTS schema_migrations/i.test(s)) return [[], []];
+      if (/SELECT filename FROM schema_migrations/i.test(s)) {
+        return [applied.map((f) => ({ filename: f })), []];
+      }
+      if (/INSERT INTO schema_migrations/i.test(s)) {
+        applied.push(params[0]);
+        return [{ affectedRows: 1 }, []];
+      }
+      queries.push(s);
+      return [[], []];
+    },
+  };
+  return { conn, applied, queries };
+}
+
+describe("applySchema", () => {
+  it("runs the preamble-stripped schema as a single multi-statement query", async () => {
+    const { conn, queries } = makeFakeDb();
+    const ran = await applySchema(conn, schemaSql);
+    expect(queries.length).toBe(1);
+    expect(queries[0]).toBe(ran);
+    expect(/CREATE\s+DATABASE/i.test(queries[0])).toBe(false);
+    expect(/CREATE\s+TABLE\s+IF\s+NOT\s+EXISTS/i.test(queries[0])).toBe(true);
+  });
+});
+
+describe("initDatabase", () => {
+  it("applies schema first, then every migration, and is a clean no-op on re-run", async () => {
+    const files = listMigrationFiles();
+    const { conn, applied, queries } = makeFakeDb();
+
+    const first = await initDatabase(conn);
+    // schema body query is recorded before any migration body query.
+    expect(queries.length).toBeGreaterThan(0);
+    expect(/CREATE\s+TABLE\s+IF\s+NOT\s+EXISTS/i.test(queries[0])).toBe(true);
+    expect(first.applied).toEqual(files);
+    expect(applied).toEqual(files);
+
+    const queriesAfterFirst = queries.length;
+
+    // Second run: schema re-applies (idempotent CREATE/INSERT IF NOT EXISTS) but
+    // no migration is recorded twice.
+    const second = await initDatabase(conn);
+    expect(second.applied).toEqual([]);
+    expect(applied).toEqual(files);
+    // Only the schema query was re-issued, no new migration bodies.
+    expect(queries.length).toBe(queriesAfterFirst + 1);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "db:init": "node db/init.mjs",
     "migrate": "node db/migrate.mjs",
     "test": "vitest run"
   },


### PR DESCRIPTION
## Problem

A fresh database needed `db/schema.sql` applied **first**, then `npm run migrate`. Running `npm run migrate` alone on an empty DB failed confusingly — migration `001` is an `ALTER TABLE page_templates` that assumes the table already exists (it only does after `schema.sql` runs). This was a real bootstrap stumbling block.

## Change

- **`db/init.mjs` + `npm run db:init`**: THE single command to initialize a database. Applies `db/schema.sql` (from-scratch snapshot), then runs the migration runner — DB ends fully up to date in one step.
- **Idempotent / safe to re-run**: schema uses `CREATE TABLE IF NOT EXISTS` + `WHERE NOT EXISTS`/`ON DUPLICATE KEY` seeds; migrations are recorded in `schema_migrations`. A double-run is a clean no-op and reports "already initialized".
- **Connects directly to the configured `DB_NAME`**: strips the leading `CREATE DATABASE`/`USE glow_cms` lines from `schema.sql` (`stripSchemaPreamble`), so it works even when the DB user can't `CREATE DATABASE` or the database is named something other than `glow_cms`.
- **Reuses `loadConfig()`** (env vars / `.db-config.json`) like the app and migrator; `--env-file` works for Node.
- **Docs**: README and AGENT.md now document `db:init` as the setup command; `npm run migrate` is noted as the upgrade tool for already-initialized DBs.

## Tests

`db/init.test.js` covers the strip-preamble logic, schema-then-migrations ordering, and double-run idempotency using a fake connection.

- `npm run build` — exit 0
- `npm test` — 166 passed (16 files)