### PR TITLE
Add in-app bulk AI content generation to admin Pages list

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -94,6 +94,35 @@ prompt drives every LLM call. The pure version-selection logic lives in `lib/pro
    - If `truncated`, the route returns HTTP 502 with a `truncated: true` warning instead of storing/returning the partial page.
 5. Return generated HTML
 
+### Bulk AI Content Generation (admin Pages list)
+
+The Pages list (`app/cms-admin/page.js`) has a **"✨ Generate Content"** batch action so an
+admin can AI-generate (and regenerate) landing-page content across many pages without an
+external script — this productizes what the bootstrap `generate-*` scripts did manually.
+
+- **Selection + filters:** per-row checkboxes plus status (draft/published) and category
+  filters; "select all" applies to the currently-filtered rows. Selected pages feed the
+  `BulkGenerate` modal (`app/cms-admin/components/BulkGenerate.js`).
+- **Client-driven (no HTTP timeout):** the browser iterates the selected pages **serially**,
+  reusing the existing single-page endpoints per page — `GET /api/pages/[id]` → `POST /api/generate`
+  → `PUT /api/pages/[id]`. Nothing tries to do all N inside one server request. Live progress
+  (X of N, current page, per-page ✓/✗) and a final summary are shown; a failed page never
+  aborts the batch — failures are collected and a **"Retry failed"** button re-runs only those.
+- **Provider:** defaults to Gemini `gemini-2.5-flash` (best quality/$), with OpenAI as the
+  fallback option. Anthropic is intentionally omitted from the picker (currently billing-blocked);
+  provider errors (unconfigured key, billing) surface as the per-page failure message rather
+  than hanging.
+- **Idempotent / regenerate-not-duplicate:** generated HTML is saved into one chosen section
+  type per page. Re-running **replaces** that section in place instead of appending a duplicate.
+  An optional "set to published" toggle confirms before overwriting already-published pages.
+- **Where the logic lives / why:** the get-it-wrong pieces are pure functions in
+  `lib/bulkGenerate.js` (DOM/DB-free, unit-tested in `lib/bulkGenerate.test.js`):
+  `mergeGeneratedSection` (replace-not-duplicate), `runBulkGeneration` (serial iteration +
+  per-page failure isolation + progress events), `buildBulkPrompt`, and `failedPages` (retry
+  input). The component only wires `fetch` calls into these.
+- **Follow-ups (deferred):** auto-generating per-page SEO meta during the batch (see issue #88),
+  and a small bounded concurrency for the generate step (kept serial in v1 for simplicity).
+
 ## URL Routing
 
 | Route | Purpose |

--- a/app/cms-admin/components/BulkGenerate.js
+++ b/app/cms-admin/components/BulkGenerate.js
@@ -1,0 +1,208 @@
+"use client";
+import { useState } from "react";
+import { buildBulkPrompt, mergeGeneratedSection, runBulkGeneration, failedPages } from "@/lib/bulkGenerate";
+
+const PROVIDERS = [
+  { value: "gemini", label: "Gemini (2.5 Flash)" },
+  { value: "openai", label: "OpenAI (GPT-4o-mini)" },
+];
+
+// One page's full pipeline: fetch its current sections → POST /api/generate →
+// merge the HTML into the chosen section (replace-not-duplicate) → PUT the page.
+// Throws (with a clear message) on any failure so the orchestrator records it.
+function makeProcessPage({ provider, sectionTypeId, publish, extra, categoryById }) {
+  return async (page) => {
+    const detail = await fetch(`/api/pages/${page.id}`).then((r) => r.json());
+    if (detail.error) throw new Error(detail.error);
+
+    const cat = page.category_id ? categoryById[page.category_id] : null;
+    const prompt = buildBulkPrompt(page, {
+      categoryName: cat?.name,
+      categoryDescription: cat?.description,
+      extra,
+    });
+
+    const genRes = await fetch("/api/generate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ provider, prompt }),
+    });
+    const gen = await genRes.json();
+    if (!genRes.ok || gen.error) {
+      throw new Error(gen.error || `Generation failed (HTTP ${genRes.status})`);
+    }
+
+    const sections = mergeGeneratedSection(detail.sections, sectionTypeId, gen.html);
+    const putRes = await fetch(`/api/pages/${page.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: detail.title,
+        slug: detail.slug,
+        header_id: detail.header_id,
+        footer_id: detail.footer_id,
+        page_template_id: detail.page_template_id,
+        status: publish ? "published" : detail.status,
+        category_id: detail.category_id,
+        meta_title: detail.meta_title,
+        meta_description: detail.meta_description,
+        og_image: detail.og_image,
+        canonical: detail.canonical,
+        sections,
+      }),
+    });
+    if (!putRes.ok) {
+      const err = await putRes.json().catch(() => ({}));
+      throw new Error(err.error || `Save failed (HTTP ${putRes.status})`);
+    }
+  };
+}
+
+export default function BulkGenerate({ pages, sectionTypes, categories, onClose, onDone }) {
+  const [provider, setProvider] = useState("gemini");
+  const [sectionTypeId, setSectionTypeId] = useState(sectionTypes[0]?.id || "");
+  const [publish, setPublish] = useState(false);
+  const [extra, setExtra] = useState("");
+  const [running, setRunning] = useState(false);
+  const [progress, setProgress] = useState(null); // { index, total, currentTitle }
+  const [rowResults, setRowResults] = useState({}); // id -> { status, error }
+  const [summary, setSummary] = useState(null); // { pages, results }
+
+  const categoryById = Object.fromEntries(
+    categories.flatMap((p) => [p, ...(p.children || [])]).map((c) => [c.id, c])
+  );
+
+  const publishedCount = pages.filter((p) => p.status === "published").length;
+
+  async function run(targetPages) {
+    setRunning(true);
+    setSummary(null);
+    setRowResults((prev) => {
+      const next = { ...prev };
+      targetPages.forEach((p) => { next[p.id] = { status: "queued" }; });
+      return next;
+    });
+
+    const processPage = makeProcessPage({ provider, sectionTypeId, publish, extra, categoryById });
+    const results = await runBulkGeneration(targetPages, {
+      processPage,
+      onProgress: ({ index, total, page, status, result }) => {
+        if (status === "running") {
+          setProgress({ index, total, currentTitle: page.title });
+          setRowResults((prev) => ({ ...prev, [page.id]: { status: "running" } }));
+        } else {
+          setRowResults((prev) => ({ ...prev, [page.id]: { status, error: result?.error } }));
+        }
+      },
+    });
+
+    setRunning(false);
+    setProgress(null);
+    setSummary({ pages: targetPages, results });
+    onDone?.();
+  }
+
+  function start() {
+    if (publish && publishedCount > 0 &&
+        !confirm(`This will overwrite content on ${publishedCount} already-published page(s). Continue?`)) {
+      return;
+    }
+    if (!publish && publishedCount > 0 &&
+        !confirm(`${publishedCount} of these page(s) are already published. Their content will be regenerated and overwritten in place. Continue?`)) {
+      return;
+    }
+    run(pages);
+  }
+
+  const failed = summary ? failedPages(summary.pages, summary.results) : [];
+  const okCount = summary ? summary.results.filter((r) => r.ok).length : 0;
+
+  return (
+    <>
+      <div onClick={running ? undefined : onClose} style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,.4)", zIndex: 1000 }} />
+      <div style={{ position: "fixed", top: "50%", left: "50%", transform: "translate(-50%,-50%)", background: "var(--bg)", borderRadius: 8, padding: 24, zIndex: 1001, width: 520, maxHeight: "85vh", overflow: "auto", boxShadow: "0 8px 30px rgba(0,0,0,.2)" }}>
+        <h3 style={{ margin: "0 0 4px" }}>Generate Content</h3>
+        <p style={{ fontSize: 13, color: "var(--text-muted)", margin: "0 0 16px" }}>
+          AI-generate and save content for {pages.length} selected page{pages.length === 1 ? "" : "s"}, one at a time.
+        </p>
+
+        {!summary && (
+          <>
+            <div className="form-field">
+              <label>Provider</label>
+              <select className="form-input" value={provider} onChange={(e) => setProvider(e.target.value)} disabled={running}>
+                {PROVIDERS.map((p) => <option key={p.value} value={p.value}>{p.label}</option>)}
+              </select>
+              <p style={{ fontSize: 12, color: "var(--text-muted)", marginTop: 4 }}>Default Gemini (best quality/$). Anthropic is intentionally omitted — it is currently billing-blocked.</p>
+            </div>
+            <div className="form-field">
+              <label>Save into section type</label>
+              <select className="form-input" value={sectionTypeId} onChange={(e) => setSectionTypeId(e.target.value)} disabled={running}>
+                {sectionTypes.map((t) => <option key={t.id} value={t.id}>{t.name}</option>)}
+              </select>
+              <p style={{ fontSize: 12, color: "var(--text-muted)", marginTop: 4 }}>Re-running replaces this section on each page — it never duplicates.</p>
+            </div>
+            <div className="form-field">
+              <label>Extra instructions (optional)</label>
+              <textarea className="form-input" rows={2} value={extra} onChange={(e) => setExtra(e.target.value)} disabled={running} placeholder="Applied to every page, e.g. “Use a friendly tone, include a CTA.”" />
+            </div>
+            <label style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 14, margin: "8px 0 16px" }}>
+              <input type="checkbox" checked={publish} onChange={(e) => setPublish(e.target.checked)} disabled={running} />
+              Set pages to <strong>published</strong> after generating
+            </label>
+          </>
+        )}
+
+        {(running || summary) && (
+          <div style={{ margin: "8px 0 16px", border: "1px solid var(--border)", borderRadius: 6, maxHeight: 280, overflow: "auto" }}>
+            {pages.map((p) => {
+              const r = rowResults[p.id] || {};
+              const icon = r.status === "ok" ? "✓" : r.status === "failed" ? "✗" : r.status === "running" ? "⟳" : "·";
+              const color = r.status === "ok" ? "var(--success, #16a34a)" : r.status === "failed" ? "var(--danger)" : "var(--text-muted)";
+              return (
+                <div key={p.id} style={{ display: "flex", gap: 8, alignItems: "baseline", padding: "5px 10px", fontSize: 13, borderBottom: "1px solid var(--border)" }}>
+                  <span style={{ color, width: 14 }}>{icon}</span>
+                  <span style={{ flex: 1 }}>{p.title}</span>
+                  {r.error && <span style={{ color: "var(--danger)", fontSize: 12, maxWidth: 240, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }} title={r.error}>{r.error}</span>}
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {running && progress && (
+          <p style={{ fontSize: 13, color: "var(--text-muted)" }}>
+            Generating {progress.index + 1} of {progress.total}: <strong>{progress.currentTitle}</strong>…
+          </p>
+        )}
+
+        {summary && (
+          <p style={{ fontSize: 14, margin: "4px 0 12px" }}>
+            Done: <span style={{ color: "var(--success, #16a34a)" }}>{okCount} succeeded</span>
+            {failed.length > 0 && <>, <span style={{ color: "var(--danger)" }}>{failed.length} failed</span></>}.
+          </p>
+        )}
+
+        <div style={{ display: "flex", gap: 8, justifyContent: "flex-end", marginTop: 8 }}>
+          {!running && !summary && (
+            <>
+              <button type="button" className="btn btn-ghost" onClick={onClose}>Cancel</button>
+              <button type="button" className="btn btn-primary" onClick={start} disabled={!sectionTypeId || !pages.length}>
+                Generate {pages.length} page{pages.length === 1 ? "" : "s"}
+              </button>
+            </>
+          )}
+          {running && <button type="button" className="btn btn-ghost" disabled>Running…</button>}
+          {summary && (
+            <>
+              {failed.length > 0 && (
+                <button type="button" className="btn btn-secondary" onClick={() => run(failed)}>Retry {failed.length} failed</button>
+              )}
+              <button type="button" className="btn btn-primary" onClick={onClose}>Close</button>
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/cms-admin/page.js
+++ b/app/cms-admin/page.js
@@ -1,17 +1,28 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import Link from "next/link";
+import BulkGenerate from "./components/BulkGenerate";
 
 export default function Home() {
   const [pages, setPages] = useState([]);
   const [contentPath, setContentPath] = useState("");
+  const [sectionTypes, setSectionTypes] = useState([]);
+  const [categories, setCategories] = useState([]);
+  const [selected, setSelected] = useState(new Set());
+  const [statusFilter, setStatusFilter] = useState("all"); // all | draft | published
+  const [categoryFilter, setCategoryFilter] = useState("all"); // "all" | category id (string)
+  const [showBulk, setShowBulk] = useState(false);
+
+  const loadPages = () => fetch("/api/pages").then(r => r.json()).then(setPages);
 
   useEffect(() => {
-    fetch("/api/pages").then(r => r.json()).then(setPages);
+    loadPages();
     fetch("/api/site-config").then(r => r.json()).then(c => {
       const cp = c.content_path || "";
       setContentPath(!cp || cp === "/" ? "" : cp.startsWith("/") ? cp : `/${cp}`);
     });
+    fetch("/api/section-types").then(r => r.json()).then(setSectionTypes);
+    fetch("/api/categories").then(r => r.json()).then(setCategories);
   }, []);
 
   function publicUrl(slug) { return `${contentPath}/${slug}`; }
@@ -20,7 +31,25 @@ export default function Home() {
     if (!confirm("Delete this page?")) return;
     await fetch(`/api/pages/${id}`, { method: "DELETE" });
     setPages(pages.filter(p => p.id !== id));
+    setSelected(prev => { const n = new Set(prev); n.delete(id); return n; });
   }
+
+  const visible = useMemo(() => pages.filter(p =>
+    (statusFilter === "all" || p.status === statusFilter) &&
+    (categoryFilter === "all" || String(p.category_id) === categoryFilter)
+  ), [pages, statusFilter, categoryFilter]);
+
+  const visibleIds = visible.map(p => p.id);
+  const allVisibleSelected = visibleIds.length > 0 && visibleIds.every(id => selected.has(id));
+
+  function toggle(id) {
+    setSelected(prev => { const n = new Set(prev); n.has(id) ? n.delete(id) : n.add(id); return n; });
+  }
+  function toggleAll() {
+    setSelected(prev => allVisibleSelected ? new Set([...prev].filter(id => !visibleIds.includes(id))) : new Set([...prev, ...visibleIds]));
+  }
+
+  const selectedPages = pages.filter(p => selected.has(p.id));
 
   return (
     <>
@@ -28,14 +57,41 @@ export default function Home() {
         <h1>Pages</h1>
         <Link href="/cms-admin/pages/new/edit" className="btn btn-primary">+ Add New</Link>
       </div>
+
+      <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap", marginBottom: 12 }}>
+        <label style={{ fontSize: 13, color: "var(--text-muted)" }}>Status</label>
+        <select className="form-input" style={{ width: 130 }} value={statusFilter} onChange={e => setStatusFilter(e.target.value)}>
+          <option value="all">All</option>
+          <option value="draft">Draft</option>
+          <option value="published">Published</option>
+        </select>
+        <label style={{ fontSize: 13, color: "var(--text-muted)" }}>Category</label>
+        <select className="form-input" style={{ width: 200 }} value={categoryFilter} onChange={e => setCategoryFilter(e.target.value)}>
+          <option value="all">All</option>
+          {categories.map(p => [
+            <option key={p.id} value={String(p.id)}>{p.name}</option>,
+            ...(p.children || []).map(c => <option key={c.id} value={String(c.id)}>&nbsp;&nbsp;↳ {c.name}</option>)
+          ])}
+        </select>
+        <span style={{ flex: 1 }} />
+        <span style={{ fontSize: 13, color: "var(--text-muted)" }}>{selected.size} selected</span>
+        <button className="btn btn-primary btn-sm" disabled={!selected.size || !sectionTypes.length} onClick={() => setShowBulk(true)} title={!sectionTypes.length ? "Create a section type first" : ""}>
+          ✨ Generate Content ({selected.size})
+        </button>
+      </div>
+
       <div className="table-wrap">
         <table>
           <thead>
-            <tr><th>Title</th><th>URL</th><th>Status</th><th>Actions</th></tr>
+            <tr>
+              <th style={{ width: 32 }}><input type="checkbox" checked={allVisibleSelected} onChange={toggleAll} /></th>
+              <th>Title</th><th>URL</th><th>Status</th><th>Actions</th>
+            </tr>
           </thead>
           <tbody>
-            {pages.map(p => (
+            {visible.map(p => (
               <tr key={p.id}>
+                <td><input type="checkbox" checked={selected.has(p.id)} onChange={() => toggle(p.id)} /></td>
                 <td><Link href={`/cms-admin/pages/${p.id}`} className="link">{p.title}</Link></td>
                 <td style={{ fontSize: 13, color: "var(--text-muted)" }}>{publicUrl(p.slug)}</td>
                 <td><span className={`badge badge-${p.status}`}>{p.status}</span></td>
@@ -46,10 +102,20 @@ export default function Home() {
                 </td>
               </tr>
             ))}
-            {!pages.length && <tr><td colSpan={4} style={{ textAlign: "center", color: "var(--text-muted)", padding: 40 }}>No pages yet. Create your first page!</td></tr>}
+            {!visible.length && <tr><td colSpan={5} style={{ textAlign: "center", color: "var(--text-muted)", padding: 40 }}>{pages.length ? "No pages match the filters." : "No pages yet. Create your first page!"}</td></tr>}
           </tbody>
         </table>
       </div>
+
+      {showBulk && (
+        <BulkGenerate
+          pages={selectedPages}
+          sectionTypes={sectionTypes}
+          categories={categories}
+          onClose={() => setShowBulk(false)}
+          onDone={loadPages}
+        />
+      )}
     </>
   );
 }

--- a/lib/bulkGenerate.js
+++ b/lib/bulkGenerate.js
@@ -1,0 +1,98 @@
+// Pure logic for the in-app bulk AI content generator (admin → Pages list).
+//
+// The actual network calls (POST /api/generate, PUT /api/pages/[id]) live in the
+// client component so they can stream live progress without an HTTP timeout. The
+// pieces that are easy to get wrong — "regenerate must REPLACE, not duplicate" and
+// "one failed page must not abort the batch" — are isolated here so they can be
+// unit-tested without a DOM or a database.
+
+// Build the LLM prompt for one page from its title and any category context.
+// `extra` is optional free-text the admin can add in the batch dialog (applied to
+// every page in the run).
+export function buildBulkPrompt(page, { categoryName, categoryDescription, extra } = {}) {
+  const lines = [
+    `Generate complete, production-ready landing-page body content for the page titled "${page.title}".`,
+  ];
+  if (categoryName) lines.push(`Category: ${categoryName}.`);
+  if (categoryDescription) lines.push(`Context: ${categoryDescription}`);
+  if (extra && extra.trim()) lines.push(extra.trim());
+  lines.push(
+    "Return only the inner HTML for the page body (no <html>/<head>/<body> wrappers, no markdown code fences, no {{placeholders}})."
+  );
+  return lines.join("\n");
+}
+
+// Merge freshly generated HTML into a page's existing sections as the single
+// "generated content" section, identified by `sectionTypeId`.
+//
+// Idempotency contract: if the page already has a section of that type (i.e. this
+// page was generated before, or the type was seeded by the page template), REPLACE
+// its content in place. Otherwise append a new section. This is what makes a
+// re-run a regenerate instead of stacking duplicate sections.
+//
+// Returns a fresh sections array shaped for PUT /api/pages/[id] — each entry keeps
+// only { section_type_id, content, variables }, dropping join columns like
+// type_name so they don't get round-tripped back into the DB.
+export function mergeGeneratedSection(existingSections, sectionTypeId, html) {
+  const typeId = Number(sectionTypeId);
+  const sections = (existingSections || []).map((s) => ({
+    section_type_id: Number(s.section_type_id),
+    content: s.content,
+    variables: normalizeVariables(s.variables),
+  }));
+  const idx = sections.findIndex((s) => s.section_type_id === typeId);
+  if (idx >= 0) {
+    sections[idx] = { ...sections[idx], content: html };
+  } else {
+    sections.push({ section_type_id: typeId, content: html, variables: {} });
+  }
+  return sections;
+}
+
+function normalizeVariables(variables) {
+  if (!variables) return {};
+  if (typeof variables === "string") {
+    try {
+      return JSON.parse(variables) || {};
+    } catch {
+      return {};
+    }
+  }
+  return variables;
+}
+
+// Run a batch over `pages` serially, one page at a time, so each generate call is
+// modest and the publish step is never concurrent (the publish deadlock fix is
+// server-side, but we keep the client well-behaved). A page that throws is
+// recorded as a failure and the batch continues — it never aborts the run.
+//
+//   processPage(page, index) -> Promise   // does generate + save for one page; throws on failure
+//   onProgress({ index, total, page, status, result }) -> void
+//     status: "running" before, then "ok" | "failed" after.
+//
+// Returns an array of { id, title, ok, error? } in input order. Re-running with
+// only the failed pages (see failedPages) is how "retry failures" works.
+export async function runBulkGeneration(pages, { processPage, onProgress } = {}) {
+  const results = [];
+  for (let i = 0; i < pages.length; i++) {
+    const page = pages[i];
+    onProgress?.({ index: i, total: pages.length, page, status: "running" });
+    let result;
+    try {
+      await processPage(page, i);
+      result = { id: page.id, title: page.title, ok: true };
+    } catch (e) {
+      result = { id: page.id, title: page.title, ok: false, error: e?.message || String(e) };
+    }
+    results.push(result);
+    onProgress?.({ index: i, total: pages.length, page, status: result.ok ? "ok" : "failed", result });
+  }
+  return results;
+}
+
+// Given a results array from runBulkGeneration and the pages that produced it,
+// return the subset of pages whose generation failed — the input for a retry run.
+export function failedPages(pages, results) {
+  const failedIds = new Set(results.filter((r) => !r.ok).map((r) => r.id));
+  return pages.filter((p) => failedIds.has(p.id));
+}

--- a/lib/bulkGenerate.test.js
+++ b/lib/bulkGenerate.test.js
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  buildBulkPrompt,
+  mergeGeneratedSection,
+  runBulkGeneration,
+  failedPages,
+} from "./bulkGenerate.js";
+
+describe("buildBulkPrompt", () => {
+  it("includes the page title", () => {
+    const p = buildBulkPrompt({ title: "Teeth Whitening" }, {});
+    expect(p).toContain('"Teeth Whitening"');
+  });
+  it("folds in category context and admin extra instructions", () => {
+    const p = buildBulkPrompt(
+      { title: "Botox" },
+      { categoryName: "Aesthetics", categoryDescription: "Facial treatments", extra: "Keep it under 300 words." }
+    );
+    expect(p).toContain("Aesthetics");
+    expect(p).toContain("Facial treatments");
+    expect(p).toContain("Keep it under 300 words.");
+  });
+  it("always forbids fences and placeholders so saved HTML is clean", () => {
+    const p = buildBulkPrompt({ title: "X" }, {});
+    expect(p).toMatch(/no markdown code fences/i);
+    expect(p).toMatch(/\{\{placeholders\}\}/);
+  });
+});
+
+describe("mergeGeneratedSection — regenerate replaces, never duplicates", () => {
+  it("appends when the page has no section of the generated type", () => {
+    const out = mergeGeneratedSection([], 3, "<section>new</section>");
+    expect(out).toHaveLength(1);
+    expect(out[0]).toEqual({ section_type_id: 3, content: "<section>new</section>", variables: {} });
+  });
+
+  it("REPLACES the existing section of that type in place (regenerate)", () => {
+    const existing = [{ section_type_id: 3, content: "<section>old</section>", variables: {} }];
+    const out = mergeGeneratedSection(existing, 3, "<section>fresh</section>");
+    expect(out).toHaveLength(1); // not 2 — no duplicate
+    expect(out[0].content).toBe("<section>fresh</section>");
+  });
+
+  it("treats string and number section_type_id as the same type", () => {
+    const existing = [{ section_type_id: "3", content: "old" }];
+    const out = mergeGeneratedSection(existing, 3, "fresh");
+    expect(out).toHaveLength(1);
+    expect(out[0].content).toBe("fresh");
+  });
+
+  it("preserves other sections and their order, replacing only the matching type", () => {
+    const existing = [
+      { section_type_id: 1, content: "hero" },
+      { section_type_id: 3, content: "old-body" },
+      { section_type_id: 5, content: "cta" },
+    ];
+    const out = mergeGeneratedSection(existing, 3, "new-body");
+    expect(out.map((s) => s.content)).toEqual(["hero", "new-body", "cta"]);
+  });
+
+  it("parses string-encoded variables and strips join columns like type_name", () => {
+    const existing = [{ section_type_id: 1, content: "hero", variables: '{"a":"b"}', type_name: "Hero" }];
+    const out = mergeGeneratedSection(existing, 3, "body");
+    expect(out[0]).toEqual({ section_type_id: 1, content: "hero", variables: { a: "b" } });
+    expect(out[0]).not.toHaveProperty("type_name");
+  });
+});
+
+describe("runBulkGeneration — failure isolation + progress", () => {
+  it("processes every page and reports success in input order", async () => {
+    const pages = [{ id: 1, title: "A" }, { id: 2, title: "B" }];
+    const processPage = vi.fn().mockResolvedValue();
+    const results = await runBulkGeneration(pages, { processPage });
+    expect(processPage).toHaveBeenCalledTimes(2);
+    expect(results).toEqual([
+      { id: 1, title: "A", ok: true },
+      { id: 2, title: "B", ok: true },
+    ]);
+  });
+
+  it("a failed page does not abort the batch; the error is collected", async () => {
+    const pages = [{ id: 1, title: "A" }, { id: 2, title: "B" }, { id: 3, title: "C" }];
+    const processPage = vi.fn(async (p) => {
+      if (p.id === 2) throw new Error("billing-blocked");
+    });
+    const results = await runBulkGeneration(pages, { processPage });
+    expect(processPage).toHaveBeenCalledTimes(3); // continued past the failure
+    expect(results[1]).toEqual({ id: 2, title: "B", ok: false, error: "billing-blocked" });
+    expect(results[0].ok).toBe(true);
+    expect(results[2].ok).toBe(true);
+  });
+
+  it("runs serially — never two processPage calls in flight at once", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const processPage = vi.fn(async () => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await Promise.resolve();
+      inFlight--;
+    });
+    await runBulkGeneration([{ id: 1 }, { id: 2 }, { id: 3 }], { processPage });
+    expect(maxInFlight).toBe(1);
+  });
+
+  it("emits a running event then a terminal ok/failed event per page", async () => {
+    const events = [];
+    const processPage = async (p) => {
+      if (p.id === 2) throw new Error("boom");
+    };
+    await runBulkGeneration([{ id: 1, title: "A" }, { id: 2, title: "B" }], {
+      processPage,
+      onProgress: (e) => events.push([e.index, e.status]),
+    });
+    expect(events).toEqual([
+      [0, "running"],
+      [0, "ok"],
+      [1, "running"],
+      [1, "failed"],
+    ]);
+  });
+});
+
+describe("failedPages — input for retrying only what failed", () => {
+  it("returns just the pages whose result was a failure", () => {
+    const pages = [{ id: 1, title: "A" }, { id: 2, title: "B" }, { id: 3, title: "C" }];
+    const results = [
+      { id: 1, ok: true },
+      { id: 2, ok: false, error: "x" },
+      { id: 3, ok: false, error: "y" },
+    ];
+    expect(failedPages(pages, results)).toEqual([{ id: 2, title: "B" }, { id: 3, title: "C" }]);
+  });
+
+  it("returns an empty array when everything succeeded", () => {
+    const pages = [{ id: 1 }];
+    expect(failedPages(pages, [{ id: 1, ok: true }])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What an admin can now do

A new **"✨ Generate Content"** batch action on the admin Pages list (`/cms-admin`) lets an admin AI-generate and **regenerate** landing-page content across many pages — entirely in-app, no external script. This productizes what the bootstrap `generate-*` scripts did manually.

**Workflow**
1. Filter the Pages list by status (draft/published) and/or category, tick the pages to fill (or "select all" the filtered set).
2. Click **Generate Content (N)** → pick a provider, the section type to save into, optional extra instructions, and whether to publish after.
3. The browser runs the batch **client-side, one page at a time**, reusing the existing single-page endpoints per page (`GET /api/pages/[id]` → `POST /api/generate` → `PUT /api/pages/[id]`). It shows live progress (X of N, current page, per-page ✓/✗) and a final summary.

**Key behaviors**
- **No HTTP timeouts:** nothing tries to do all N inside one server request; the run is serial and the publish step is never concurrent.
- **Idempotent / regenerate-not-duplicate:** generated HTML is saved into one chosen section type per page; re-running **replaces** that section in place instead of appending duplicates. Confirms before overwriting already-published content.
- **Provider choice:** defaults to **Gemini 2.5-flash** (best quality/$), OpenAI as fallback. Anthropic is intentionally omitted (currently billing-blocked); provider errors (missing key, billing) surface as a per-page failure message instead of hanging.
- **Robust:** a failed page never aborts the batch — failures are collected and a **"Retry failed"** button re-runs only those.

## Tests
- The get-it-wrong logic is pure and DOM/DB-free in `lib/bulkGenerate.js`, unit-tested in `lib/bulkGenerate.test.js` (14 tests): `mergeGeneratedSection` (replace-not-duplicate), `runBulkGeneration` (serial execution + per-page failure isolation + progress events), `buildBulkPrompt`, `failedPages`.
- `npm run build` exits 0; `npm test` passes (16 files, 174 tests).

## Follow-ups (deferred)
- Auto-generate per-page SEO meta during the batch (see issue #88).
- Optional small bounded concurrency for the generate step (kept serial in v1 for simplicity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
